### PR TITLE
Fixed IPHelix rotation, added name of the specialization to unit tests ROOT files

### DIFF
--- a/KinKal/IPHelix.hh
+++ b/KinKal/IPHelix.hh
@@ -94,6 +94,7 @@ namespace KinKal {
       double Q() const { return mass_/mbar_; } // reduced charge
       double beta() const { return fabs(pbar()/ebar()); } // relativistic beta
       double gamma() const { return fabs(ebar()/mbar_); } // relativistic gamma
+      double betaGamma() const { return fabs(pbar()/mbar_); } // relativistic betagamma
       double dphi(double t) const { return omega()*vt()*(t - t0()); }
       double phi(double t) const { return dphi(t) + phi0(); }
       double deltaPhi(double &phi, double refphi=0.) const;

--- a/KinKal/TPoca_IPHelix.cc
+++ b/KinKal/TPoca_IPHelix.cc
@@ -78,7 +78,6 @@ namespace KinKal {
       partPoca_.SetE(htoca);
       sensPoca_.SetE(stoca);
       iphelix.position(partPoca_);
-      // std::cout << "Time " << partPoca_.T() << std::endl;
       tline.position(sensPoca_);
       // sign doca by angular momentum projected onto difference vector
       double lsign = tline.dir().Cross(iphelix.direction(partPoca_.T())).Dot(sensPoca_.Vect()-partPoca_.Vect());

--- a/UnitTests/BFieldTest.hh
+++ b/UnitTests/BFieldTest.hh
@@ -168,7 +168,7 @@ int BFieldTest(int argc, char **argv) {
   cout << "Nominal " << start << " integral " << ndp << endl;
 
 // setup histograms
-  TFile tpfile("BField.root","RECREATE");
+  TFile tpfile((KTRAJ::trajName()+"BField.root").c_str(),"RECREATE");
   TH1F *dxmomt1, *dxmomt2, *dxmommd;
   TH1F *dlmomt1, *dlmomt2, *dlmommd;
   TH1F *dxpost1, *dxpost2, *dxposmd;

--- a/UnitTests/FitTest.hh
+++ b/UnitTests/FitTest.hh
@@ -292,7 +292,7 @@ int FitTest(int argc, char **argv) {
 // create and fit the track
   KKTRK kktrk(configptr,seedtraj,thits,dxings);
 //  kktrk.print(cout,detail);
-  TFile fitfile(tfname.c_str(),"RECREATE");
+  TFile fitfile((KTRAJ::trajName() + tfname).c_str(),"RECREATE");
   // tree variables
   KTRAJPars ftpars_, etpars_, spars_, ffitpars_, ffiterrs_, efitpars_, efiterrs_;
   float chisq_, etmom_, ftmom_, ffmom_, efmom_, chiprob_;
@@ -457,7 +457,7 @@ int FitTest(int argc, char **argv) {
       KTRAJ const& bftraj = kktrk.fitTraj().nearestPiece(tptraj.range().high());
       KTRAJ const& fttraj = tptraj.nearestPiece(tptraj.range().low());
       KTRAJ const& bttraj = tptraj.nearestPiece(tptraj.range().high());
-      typename KTRAJ::PDATA ftpars, btpars; 
+      typename KTRAJ::PDATA ftpars, btpars;
       if((fftraj.bnom() - fttraj.bnom()).R() < 1e-6){
 	ftpars = fftraj.params();
 	btpars = bftraj.params();

--- a/UnitTests/HitTest.hh
+++ b/UnitTests/HitTest.hh
@@ -52,7 +52,7 @@ void print_usage() {
 }
 
 template <class KTRAJ>
-int HitTest(int argc, char **argv) {
+int HitTest(int argc, char **argv, const vector<double>& delpars) {
   typedef KinKal::PKTraj<KTRAJ> PKTRAJ;
   typedef THit<KTRAJ> THIT;
   typedef std::shared_ptr<THIT> THITPTR;
@@ -128,7 +128,7 @@ int HitTest(int argc, char **argv) {
   }
 
   pmass = masses[imass];
-  TFile htfile("HitTest.root","RECREATE");
+  TFile htfile((KTRAJ::trajName()+"HitTest.root").c_str(),"RECREATE");
   // construct BField
   Vec3 bnom(0.0,By,1.0);
   BField* BF;
@@ -225,7 +225,6 @@ int HitTest(int argc, char **argv) {
   rulers->Draw();
   hcan->Write();
 // test updating the hit residual and derivatives with different trajectories
-  vector<double> delpars {0.5,0.01,0.00001,0.5,0.001,0.1}; // small parameter changes for derivative calcs
   unsigned nsteps(10);
   vector<TGraph*> hderivg(KTRAJ::NParams());
   for(size_t ipar=0;ipar < KTRAJ::NParams();ipar++){

--- a/UnitTests/IPHelixHitTest_unit.cc
+++ b/UnitTests/IPHelixHitTest_unit.cc
@@ -1,5 +1,6 @@
 #include "KinKal/IPHelix.hh"
 #include "UnitTests/HitTest.hh"
 int main(int argc, char **argv) {
-  return HitTest<IPHelix>(argc,argv);
+  vector<double> delpars {0.5,0.01,0.00001,0.5,0.001,0.1};
+  return HitTest<IPHelix>(argc,argv,delpars); // small parameter changes for derivative calcs
 }

--- a/UnitTests/KTrajDerivs_test.hh
+++ b/UnitTests/KTrajDerivs_test.hh
@@ -122,7 +122,7 @@ int test(int argc, char **argv) {
   // canvases
   TCanvas* dhcan[3];
   TCanvas* dmomcan[3];
- std::string tfname = KTRAJ::trajName() + "Derivs.root";
+  std::string tfname = KTRAJ::trajName() + "Derivs.root";
   TFile lhderiv(tfname.c_str(),"RECREATE");
   // loop over derivative directions
   double del = (dmax-dmin)/(ndel-1);

--- a/UnitTests/LHelixHitTest_unit.cc
+++ b/UnitTests/LHelixHitTest_unit.cc
@@ -1,5 +1,6 @@
 #include "KinKal/LHelix.hh"
 #include "UnitTests/HitTest.hh"
 int main(int argc, char **argv) {
-  return HitTest<LHelix>(argc,argv);
+  vector<double> delpars { 0.5, 0.1, 0.5, 0.5, 0.005, 5.0};
+  return HitTest<LHelix>(argc,argv,delpars);
 }

--- a/UnitTests/PKTrajTest.hh
+++ b/UnitTests/PKTrajTest.hh
@@ -175,7 +175,7 @@ int PKTrajTest(int argc, char **argv) {
 // draw each piece of the piecetraj
   char fname[100];
   snprintf(fname,100,"PKTraj_%s_%2.2f.root",LocalBasis::directionName(tdir).c_str(),delta);
-  TFile pkfile(fname,"RECREATE");
+  TFile pkfile((KTRAJ::trajName()+fname).c_str(),"RECREATE");
   TCanvas* pttcan = new TCanvas("pttcan","PieceKTRAJ",1000,1000);
   std::vector<TPolyLine3D*> plhel;
   int icolor(kBlue);

--- a/UnitTests/TPocaTest.hh
+++ b/UnitTests/TPocaTest.hh
@@ -95,7 +95,7 @@ int TPocaTest(int argc, char **argv) {
   double sint = sqrt(1.0-cost*cost);
   Mom4 momv(mom*sint*cos(phi),mom*sint*sin(phi),mom*cost,pmass);
   KTRAJ lhel(origin,momv,icharge,bnom);
-  TFile tpfile("TPoca.root","RECREATE");
+  TFile tpfile((KTRAJ::trajName()+"TPoca.root").c_str(),"RECREATE");
   TCanvas* ttpcan = new TCanvas("ttpcan","DToca",1200,800);
   ttpcan->Divide(3,2);
   TCanvas* dtpcan = new TCanvas("dtpcan","DDoca",1200,800);


### PR DESCRIPTION
The IPHelix `direction` method wasn't taking into account the rotation, so I fixed that (I needed to add `_l2g`). Now the output ROOT filenames of the unit tests will contain the name of the specialization, to avoid confusion. Also, now it is possible to pass the numerical derivative intervals to `HitTest` as an argument. 