### PR TITLE
Travis CI - combined macOS and linux CI testing

### DIFF
--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,4 +1,4 @@
-yum -y install make base-devel glibc-devel freetype-devel python3
+yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs
 
 #python3 -m pip install scons
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,7 +1,7 @@
 echo -en 'travis_fold:start:ContainerSetup\r'
 
 echo "set up centos7 container with CERN LCG_98"
-yum -y install which
+yum -y install which make
 
 source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc8-opt/setup.sh
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -3,7 +3,7 @@ yum -y install make base-devel glibc-devel freetype-devel
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
-setup scons v3_1_2 
+scons v3_1_2 -q p383b 
 
 rm -rf build || echo ""
 mkdir build && cd build

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,5 +1,5 @@
 yum -y install epel-release
-yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs
+yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs libcurl libcurl-devel libzstd-devel libzstd
 
 #python3 -m pip install scons
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,15 +1,14 @@
 echo -en 'travis_fold:start:SLF7ContainerSetup\r'
-echo "SLF7 Container Setup"
+echo "set up SL7 container"
 
 yum -y install epel-release
 yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs libcurl libcurl-devel libzstd-devel libzstd
-
-#python3 -m pip install scons
 
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_20_06 -f Linux64bit+3.10-2.17 -q e19:p383b:prof
 #setup -B scons v3_1_2 -q +p383b
+setup cmake v3_17_3
 
 
 echo -en 'travis_fold:end:SLF7ContainerSetup\r'
@@ -20,21 +19,11 @@ echo -en 'travis_fold:end:SLF7ContainerSetup\r'
 rm -rf build || echo ""
 mkdir build && cd build
 
-#source ../scripts/newBuild.sh prof
-#source setup.sh
-
-#scons -j 4
-
-#scons test
-
-
-setup cmake v3_17_3
-
 cmake .. -DCMAKE_BUILD_TYPE=Release
 
 make -j 8
 
 #echo -en 'travis_fold:end:Build\r'
 
-make test 
+env CTEST_OUTPUT_ON_FAILURE=1 make test 
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -3,7 +3,8 @@ yum -y install make base-devel glibc-devel freetype-devel
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
-scons v3_1_2 -q p383b 
+
+python -m pip install scons
 
 rm -rf build || echo ""
 mkdir build && cd build

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -3,15 +3,14 @@ yum -y install make base-devel glibc-devel freetype-devel
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
-setup cmake v3_9_0
+setup scons v3_1_2 
 
 rm -rf build || echo ""
 mkdir build && cd build
 
+source ../scripts/newBuild.sh prof
+source setup.sh
 
+scons -j 4
 
-cmake .. -DCMAKE_BUILD_TYPE=Release
-
-make -j 8
-
-make test
+scons test

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,16 +1,11 @@
-
-
-#yum -y install http://ftp.scientificlinux.org/linux/scientific/7x/contexts/fermilab/x86_64/yum-conf-context-fermilab-1.0-6.el7.noarch.rpm
-#sleep 1
-#yum -y upgrade
-yum -y install make base-devel glibc-devel freetype-devel # redhat-lsb-core
+yum -y install make base-devel glibc-devel freetype-devel
 
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
 setup cmake v3_9_0
 
-rm -rf build || echo "build exists"
+rm -rf build || echo ""
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,17 +1,10 @@
-echo -en 'travis_fold:start:SLF7ContainerSetup\r'
-echo "set up SL7 container"
+echo -en 'travis_fold:start:ContainerSetup\r'
 
-yum -y install epel-release
-yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs libcurl libcurl-devel libzstd-devel libzstd
+echo "set up centos7 container with CERN LCG_98"
 
-source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
-setup mu2e
-setup root v6_20_06 -f Linux64bit+3.10-2.17 -q e19:p383b:prof
-#setup -B scons v3_1_2 -q +p383b
-setup cmake v3_17_3
+source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc8-opt/setup.sh
 
-
-echo -en 'travis_fold:end:SLF7ContainerSetup\r'
+echo -en 'travis_fold:end:ContainerSetup\r'
 
 #echo -en 'travis_fold:start:Build\r'
 #echo "Build"

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,10 +1,10 @@
-yum -y install make base-devel glibc-devel freetype-devel
+yum -y install make base-devel glibc-devel freetype-devel python3
 
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
 
-python -m pip install scons
+python3 -m pip install scons
 
 rm -rf build || echo ""
 mkdir build && cd build

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -6,14 +6,22 @@ yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-li
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_20_06 -f Linux64bit+3.10-2.17 -q e19:p383b:prof
-setup -B scons v3_1_2 -q +p383b
+#setup -B scons v3_1_2 -q +p383b
 
 rm -rf build || echo ""
 mkdir build && cd build
 
-source ../scripts/newBuild.sh prof
-source setup.sh
+#source ../scripts/newBuild.sh prof
+#source setup.sh
 
-scons -j 4
+#scons -j 4
 
-scons test
+#scons test
+
+
+setup cmake v3_17_3
+
+cmake .. -DCMAKE_BUILD_TYPE=Release
+
+make -j 8
+make test 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -7,6 +7,9 @@ setup cmake v3_9_0
 
 rm -rf build || echo ""
 mkdir build && cd build
+
+
+
 cmake .. -DCMAKE_BUILD_TYPE=Release
 
 make -j 8

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,7 +1,7 @@
 echo -en 'travis_fold:start:ContainerSetup\r'
 
 echo "set up centos7 container with CERN LCG_98"
-yum -y install which make
+yum -y install which make glibc-devel glibc
 
 source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc8-opt/setup.sh
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -14,8 +14,8 @@ setup root v6_20_06 -f Linux64bit+3.10-2.17 -q e19:p383b:prof
 
 echo -en 'travis_fold:end:SLF7ContainerSetup\r'
 
-echo -en 'travis_fold:start:Build\r'
-echo "Build"
+#echo -en 'travis_fold:start:Build\r'
+#echo "Build"
 
 rm -rf build || echo ""
 mkdir build && cd build
@@ -34,7 +34,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 
 make -j 8
 
-echo -en 'travis_fold:end:Build\r'
+#echo -en 'travis_fold:end:Build\r'
 
 make test 
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,10 +1,11 @@
 yum -y install make base-devel glibc-devel freetype-devel python3
 
+#python3 -m pip install scons
+
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
-
-python3 -m pip install scons
+setup -B scons v3_1_2 -q +p383b
 
 rm -rf build || echo ""
 mkdir build && cd build

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,6 +1,7 @@
 echo -en 'travis_fold:start:ContainerSetup\r'
 
 echo "set up centos7 container with CERN LCG_98"
+yum -y install which
 
 source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc8-opt/setup.sh
 

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,3 +1,4 @@
+yum -y install epel-release
 yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs
 
 #python3 -m pip install scons

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,3 +1,6 @@
+echo -en 'travis_fold:start:SLF7ContainerSetup\r'
+echo "SLF7 Container Setup"
+
 yum -y install epel-release
 yum -y install make base-devel glibc-devel freetype-devel xxhash-devel xxhash-libs libcurl libcurl-devel libzstd-devel libzstd
 
@@ -7,6 +10,12 @@ source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_20_06 -f Linux64bit+3.10-2.17 -q e19:p383b:prof
 #setup -B scons v3_1_2 -q +p383b
+
+
+echo -en 'travis_fold:end:SLF7ContainerSetup\r'
+
+echo -en 'travis_fold:start:Build\r'
+echo "Build"
 
 rm -rf build || echo ""
 mkdir build && cd build
@@ -24,4 +33,8 @@ setup cmake v3_17_3
 cmake .. -DCMAKE_BUILD_TYPE=Release
 
 make -j 8
+
+echo -en 'travis_fold:end:Build\r'
+
 make test 
+

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,0 +1,11 @@
+source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
+setup mu2e
+setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
+setup cmake v3_9_0
+
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+
+make -j 8
+
+make test

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -4,7 +4,7 @@ yum -y install make base-devel glibc-devel freetype-devel python3
 
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
-setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
+setup root v6_20_06 -f Linux64bit+3.10-2.17 -q e19:p383b:prof
 setup -B scons v3_1_2 -q +p383b
 
 rm -rf build || echo ""

--- a/.ci-setup.sh
+++ b/.ci-setup.sh
@@ -1,8 +1,16 @@
+
+
+#yum -y install http://ftp.scientificlinux.org/linux/scientific/7x/contexts/fermilab/x86_64/yum-conf-context-fermilab-1.0-6.el7.noarch.rpm
+#sleep 1
+#yum -y upgrade
+yum -y install make base-devel glibc-devel freetype-devel # redhat-lsb-core
+
 source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
 setup mu2e
 setup root v6_18_04d -f Linux64bit+3.10-2.17 -q e19:prof
 setup cmake v3_9_0
 
+rm -rf build || echo "build exists"
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -1,7 +1,9 @@
 if [ $TRAVIS_OS_NAME = 'osx' ]; then
   wget https://root.cern/download/root_v6.22.02.macosx64-10.13-clang100.pkg
   installer -pkg root_v6.22.02.macosx64-10.13-clang100.pkg -target CurrentUserHomeDirectory
-  source ~/Applications/root_v6.22.02/bin/thisroot.sh  
+  source ~/Applications/root_v6.22.02/bin/thisroot.sh 
+  python -m pip install --user scons
+
 else
   wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
   sudo dpkg -i cvmfs-release-latest_all.deb
@@ -26,4 +28,3 @@ else
   docker pull scientificlinux/sl:7
 fi
 
-python -m pip install --user scons

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -25,6 +25,7 @@ else
   sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, will continue anyway"
   sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org || echo "mount may have failed, will continue anyway"
 
-  docker pull scientificlinux/sl:7
+  docker pull centos:7
+
 fi
 

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -3,10 +3,27 @@ if [ $TRAVIS_OS_NAME = 'osx' ]; then
   installer -pkg root_v6.22.02.macosx64-10.13-clang100.pkg -target CurrentUserHomeDirectory
   source ~/Applications/root_v6.22.02/bin/thisroot.sh  
 else
-  wget https://root.cern/download/root_v6.22.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-  tar xzvf root_v6.22.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-  source root/bin/thisroot.sh
+  wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+  sudo dpkg -i cvmfs-release-latest_all.deb
 
+  sudo apt-get update
+  sudo apt-get install cvmfs cvmfs-config-default
+  rm -f cvmfs-release-latest_all.deb
+
+  sudo /etc/init.d/autofs stop
+  sudo mkdir -p /etc/cvmfs/
+  echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
+  echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
+  sudo mv default.local /etc/cvmfs/default.local
+
+  sudo cvmfs_config setup
+  sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
+  sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
+
+  sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, will continue anyway"
+  sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org || echo "mount may have failed, will continue anyway"
+
+  docker pull scientificlinux/sl:7
 fi
 
 python -m pip install --user scons

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -3,7 +3,7 @@ if [ $TRAVIS_OS_NAME = 'osx' ]; then
   installer -pkg root_v6.22.02.macosx64-10.13-clang100.pkg -target CurrentUserHomeDirectory
   source ~/Applications/root_v6.22.02/bin/thisroot.sh 
   python3 -m pip install --user scons
-
+  export PATH=$HOME/Library/Python/3.7/bin:$PATH
 else
   wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
   sudo dpkg -i cvmfs-release-latest_all.deb

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -14,16 +14,14 @@ else
 
   sudo /etc/init.d/autofs stop
   sudo mkdir -p /etc/cvmfs/
-  echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
+  #echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
+  echo "CVMFS_REPOSITORIES=sft.cern.ch" > default.local
   echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
   sudo mv default.local /etc/cvmfs/default.local
 
   sudo cvmfs_config setup
-  sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
-  sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
-
-  sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, will continue anyway"
-  sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org || echo "mount may have failed, will continue anyway"
+  sudo mkdir -p /cvmfs/sft.cern.ch
+  sudo mount -t cvmfs sft.cern.ch /cvmfs/sft.cern.ch || echo "mount may have failed, will continue anyway"
 
   docker pull centos:7
 

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -1,0 +1,12 @@
+if [ $TRAVIS_OS_NAME = 'osx' ]; then
+  wget https://root.cern/download/root_v6.22.02.macosx64-10.13-clang100.pkg
+  installer -pkg root_v6.22.02.macosx64-10.13-clang100.pkg -target CurrentUserHomeDirectory
+  source ~/Applications/root_v6.22.02/bin/thisroot.sh  
+else
+  wget https://root.cern/download/root_v6.22.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+  tar xzvf root_v6.22.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+  source ~/root/bin/thisroot.sh
+
+fi
+
+python -m pip install --user scons

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -5,7 +5,7 @@ if [ $TRAVIS_OS_NAME = 'osx' ]; then
 else
   wget https://root.cern/download/root_v6.22.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
   tar xzvf root_v6.22.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-  source ~/root/bin/thisroot.sh
+  source root/bin/thisroot.sh
 
 fi
 

--- a/.travis-before-install.sh
+++ b/.travis-before-install.sh
@@ -2,7 +2,7 @@ if [ $TRAVIS_OS_NAME = 'osx' ]; then
   wget https://root.cern/download/root_v6.22.02.macosx64-10.13-clang100.pkg
   installer -pkg root_v6.22.02.macosx64-10.13-clang100.pkg -target CurrentUserHomeDirectory
   source ~/Applications/root_v6.22.02/bin/thisroot.sh 
-  python -m pip install --user scons
+  python3 -m pip install --user scons
 
 else
   wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb

--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -1,11 +1,15 @@
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     mkdir build && cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release
+    
+    make -j 8
+    make test
 
-    source ../scripts/newBuild.sh prof 
-    source setup.sh
+#    source ../scripts/newBuild.sh prof 
+#    source setup.sh
 
-    scons -j 4
-    scons test
+#    scons -j 4
+#    scons test
 
 else
 

--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -1,0 +1,18 @@
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    mkdir build && cd build
+
+    source ../../scripts/newBuild.sh prof 
+    source setup.sh
+
+    scons -j 4
+    scons test
+
+else
+
+    cd .. 
+
+    docker run --name KinKalCI -v /cvmfs:/cvmfs:ro,shared -v "$(pwd)"/KinKal:/KinKal -it -d scientificlinux/sl:7
+    docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
+
+fi
+

--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -1,7 +1,7 @@
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     mkdir build && cd build
 
-    source ../../scripts/newBuild.sh prof 
+    source ../scripts/newBuild.sh prof 
     source setup.sh
 
     scons -j 4

--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -3,20 +3,12 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     cmake .. -DCMAKE_BUILD_TYPE=Release
     
     make -j 8
-    make test
-
-#    source ../scripts/newBuild.sh prof 
-#    source setup.sh
-
-#    scons -j 4
-#    scons test
-
+    env CTEST_OUTPUT_ON_FAILURE=1 make test
 else
-
+    # set up SL7 docker container
     cd .. 
 
     docker run --name KinKalCI -v /cvmfs:/cvmfs:ro,shared -v "$(pwd)"/KinKal:/KinKal -it -d scientificlinux/sl:7
     docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
-
 fi
 

--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -8,7 +8,7 @@ else
     # set up SL7 docker container
     cd .. 
 
-    docker run --name KinKalCI -v /cvmfs:/cvmfs:ro,shared -v "$(pwd)"/KinKal:/KinKal -it -d scientificlinux/sl:7
+    docker run --name KinKalCI -v /cvmfs:/cvmfs:ro,shared -v "$(pwd)"/KinKal:/KinKal -it -d centos:7
     docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 
 sudo: required
-dist: trusty
+dist: xenial
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: cpp
+
 jobs:
     include:
         - os: linux
@@ -7,7 +9,6 @@ jobs:
             - docker 
         - os: osx
           osx_image: xcode10
-          language: cpp
           python: 3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
   - sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
   - sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
 
-  - sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org
-  - sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org
+  - sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, but will continue anyway"
+  - sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org || echo "mount may have failed, will continue anyway"
   
 script:
   - docker pull scientificlinux/sl:7

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   
 script:
   - docker pull scientificlinux/sl:7
-  - cd .. && docker run --name KinKalCI -it scientificlinux/sl:7 -d -v /cvmfs:/cvmfs:ro,shared -v KinKal:/KinKal /bin/bash
+  - cd .. && docker run --name KinKalCI -it -d scientificlinux/sl:7 -v /cvmfs:/cvmfs:ro,shared -v KinKal:/KinKal /bin/bash
   - docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ jobs:
         - os: osx
           osx_image: xcode10
 
+language: cpp
+python: 3.7
+
 before_install:
     - source .travis-before-install.sh
     - cd KinKal && mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,34 @@
 
-language: cpp
-python: 3.7
-os: osx
-osx_image: xcode10
+sudo: required
+dist: trusty
 
-cache:
-  directories:
-    - $HOME/Library/Caches/Homebrew
+services:
+  - docker
+
+language: cpp
 
 before_install:
-  - brew install scons
-  - wget https://root.cern/download/root_v6.22.02.macosx64-10.13-clang100.pkg
-  - installer -pkg root_v6.22.02.macosx64-10.13-clang100.pkg -target CurrentUserHomeDirectory
-  - source ~/Applications/root_v6.22.02/bin/thisroot.sh
-  - cd KinKal
-  - mkdir build
-  - cd build
-  - source ../../scripts/newBuild.sh prof
-  - source setup.sh
+  - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+  - sudo dpkg -i cvmfs-release-latest_all.deb
+  - sudo apt-get update
+  - sudo apt-get install cvmfs cvmfs-config-default
+  - rm -f cvmfs-release-latest_all.deb
 
+  - sudo /etc/init.d/autofs stop
+  - sudo mkdir -p /etc/cvmfs/
+  - sudo echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > /etc/cvmfs/default.local
+  - sudo echo "CVMFS_HTTP_PROXY=DIRECT" >> /etc/cvmfs/default.local
+
+  - sudo cvmfs_config setup
+  - sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
+  - sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
+
+  - mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org
+  - mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org
+  
 script:
-  - scons -j 4
+  - docker pull scientificlinux/sl:7
+  - cd .. && docker run --name KinKalCI -it scientificlinux/sl:7 -d -v /cvmfs:/cvmfs:ro,shared -v KinKal:/KinKal /bin/bash
+  - docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
 
-after_success:
-  - scons test
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
 
   - sudo /etc/init.d/autofs stop
   - sudo mkdir -p /etc/cvmfs/
-  - sudo echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
-  - sudo echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
+  - echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
+  - echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
   - sudo mv default.local /etc/cvmfs/default.local
 
   - sudo cvmfs_config setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   
 script:
   - docker pull scientificlinux/sl:7
-  - cd .. && docker run --name KinKalCI -it -d scientificlinux/sl:7 -v /cvmfs:/cvmfs:ro,shared -v KinKal:/KinKal /bin/bash
+  - cd .. && docker run --name KinKalCI -v /cvmfs:/cvmfs:ro,shared -v "$(pwd)"/KinKal:/KinKal -it -d scientificlinux/sl:7
   - docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
   - sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
   - sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
 
-  - mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org
-  - mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org
+  - sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org
+  - sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org
   
 script:
   - docker pull scientificlinux/sl:7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,16 @@
-
-sudo: required
-dist: xenial
-
-services:
-  - docker
-
-language: cpp
+jobs:
+    include:
+        - os: linux
+          dist: focal
+        - os: osx
+          osx_image: xcode10
 
 before_install:
-  - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-  - sudo dpkg -i cvmfs-release-latest_all.deb
-  - sudo apt-get update
-  - sudo apt-get install cvmfs cvmfs-config-default
-  - rm -f cvmfs-release-latest_all.deb
+    - source .travis-before-install.sh
+    - cd KinKal && mkdir build && cd build
+    - source ../../scripts/newBuild.sh prof
+    - source setup.sh
 
-  - sudo /etc/init.d/autofs stop
-  - sudo mkdir -p /etc/cvmfs/
-  - echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
-  - echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
-  - sudo mv default.local /etc/cvmfs/default.local
-
-  - sudo cvmfs_config setup
-  - sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
-  - sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
-
-  - sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, will continue anyway"
-  - sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org || echo "mount may have failed, will continue anyway"
-  
 script:
-  - docker pull scientificlinux/sl:7
-  - cd .. && docker run --name KinKalCI -v /cvmfs:/cvmfs:ro,shared -v "$(pwd)"/KinKal:/KinKal -it -d scientificlinux/sl:7
-  - docker exec -ti KinKalCI /bin/bash -c "cd /KinKal && source .ci-setup.sh"
-
-  
+    - scons -j 4
+    - scons test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ before_install:
 
   - sudo /etc/init.d/autofs stop
   - sudo mkdir -p /etc/cvmfs/
-  - sudo echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > /etc/cvmfs/default.local
-  - sudo echo "CVMFS_HTTP_PROXY=DIRECT" >> /etc/cvmfs/default.local
+  - sudo echo "CVMFS_REPOSITORIES=mu2e.opensciencegrid.org,fermilab.opensciencegrid.org" > default.local
+  - sudo echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
+  - sudo mv default.local /etc/cvmfs/default.local
 
   - sudo cvmfs_config setup
   - sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 jobs:
     include:
         - os: linux
-          dist: focal
+          dist: xenial
+          sudo: required
+          services:
+            - docker 
         - os: osx
           osx_image: xcode10
-
-language: cpp
-python: 3.7
+          language: cpp
+          python: 3.7
 
 before_install:
     - source .travis-before-install.sh
-    - cd KinKal && mkdir build && cd build
-    - source ../../scripts/newBuild.sh prof
-    - source setup.sh
 
 script:
-    - scons -j 4
-    - scons test
+    - source .travis-script.sh
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo mkdir -p /cvmfs/mu2e.opensciencegrid.org
   - sudo mkdir -p /cvmfs/fermilab.opensciencegrid.org
 
-  - sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, but will continue anyway"
+  - sudo mount -t cvmfs mu2e.opensciencegrid.org /cvmfs/mu2e.opensciencegrid.org || echo "mount may have failed, will continue anyway"
   - sudo mount -t cvmfs fermilab.opensciencegrid.org /cvmfs/fermilab.opensciencegrid.org || echo "mount may have failed, will continue anyway"
   
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
 project (KinKal CXX)
 
-find_package(ROOT REQUIRED COMPONENTS Core RIO Net Hist Spectrum GenVector MLP Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread Gui)
+find_package(ROOT REQUIRED COMPONENTS Core RIO Net Hist GenVector MLP Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread Gui)
 
 # include "useful" ROOT headers
 include(${ROOT_USE_FILE})

--- a/KinKal/CMakeLists.txt
+++ b/KinKal/CMakeLists.txt
@@ -2,3 +2,4 @@ file( GLOB KinKal_LIB_SOURCES *.cc )
 file( GLOB KinKal_LIB_HEADERS *.hh )
 
 add_library(KinKal SHARED ${KinKal_LIB_SOURCES} ${KinKal_LIB_HEADERS} )
+target_link_libraries(KinKal ${ROOT_LIBRARIES}) 

--- a/README.md
+++ b/README.md
@@ -100,3 +100,5 @@ You should make sure to source the `<root_location>/bin/thisroot.sh` shell scrip
 source <ROOT>/bin/thisroot.sh
 
 ```
+
+The ROOT binaries need to be compiled with C++17 (`-std=c++17`) support.

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach( testsourcefile ${TEST_APP_SOURCES} )
 
     # register the target as a test 
     add_test (NAME ${testname} COMMAND UnitTest_${testname} )
-    set_tests_properties(${testname} PROPERTIES TIMEOUT 5) 
+    set_tests_properties(${testname} PROPERTIES TIMEOUT 15) 
     set_tests_properties(${testname} PROPERTIES ENVIRONMENT "PACKAGE_SOURCE=${CMAKE_SOURCE_DIR}")
 
     install( TARGETS UnitTest_${testname}

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 
 # generate root dictionary
-ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo.hh NOINSTALL
+ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo.hh ParticleTrajectoryInfo.hh NOINSTALL
     LINKDEF LinkDef.h
 )
 add_library(UnitTests SHARED  G__Dict)

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 
 # generate root dictionary
-ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo.hh ParticleTrajectoryInfo.hh NOINSTALL
+ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo.hh ParticleTrajectoryInfo.hh MaterialInfo.hh NOINSTALL
     LINKDEF LinkDef.h
 )
 add_library(UnitTests SHARED  G__Dict)

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 
 # generate root dictionary
-ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo NOINSTALL
+ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh HitInfo NOINSTALL
     LINKDEF LinkDef.h
 )
 add_library(UnitTests SHARED  G__Dict)

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 
 # generate root dictionary
-ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh HitInfo NOINSTALL
+ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo.hh NOINSTALL
     LINKDEF LinkDef.h
 )
 add_library(UnitTests SHARED  G__Dict)


### PR DESCRIPTION
I noticed @soleti added Travis CI to this repository, which is a very good thing!

I made this a while back in June but never got around to proposing it. It executes a KinKal build and tests in an SLF7 docker container with the mu2e environment pulled from CVMFS.

One build takes about 3-4 minutes. Here is an example: https://travis-ci.org/github/ryuwd/KinKal/builds/703239979

It's not ready to merge as is, as there will be conflicts with the current `.travis.yml`, and I suspect tweaks will be necessary. It should be possible to adapt this job to also execute in parallel to the MacOS tests.
