### PR TITLE
CMake housekeeping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,48 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
 
+# find git information
+
+find_package(Git)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe
+    WORKING_DIRECTORY "${local_dir}"
+    OUTPUT_VARIABLE _build_version
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message( STATUS "git describes this revision as: ${_build_version}")
+
+  if (_build_version MATCHES "^v([0-9]+)\_([0-9]+)\_([0-9]+)\-([0-9]+)\-([a-z0-9]+)$")
+    set (_build_ver_maj ${CMAKE_MATCH_1})
+    set (_build_ver_min ${CMAKE_MATCH_2})
+    set (_build_ver_patch ${CMAKE_MATCH_3})
+    set (_build_ver_commits_since_tag ${CMAKE_MATCH_4})
+    set (_build_ver_commit_short ${CMAKE_MATCH_5})
+    message( STATUS "Version string correctly matched.")
+  endif()
+else()
+  message( STATUS "Git not found!")
+  set (_build_ver_maj 0)
+  set (_build_ver_min 0)
+  set (_build_ver_patch 0)
+  set (_build_ver_commits_since_tag 0)
+  set (_build_ver_commit_short 0)
+endif()
+
+
 # Set project name and version
 project (KinKal 
     LANGUAGES CXX 
-    VERSION 0.0.1 
+    VERSION ${_build_ver_maj}.${_build_ver_min}.${_build_ver_patch}
     DESCRIPTION "Kinematic Kalman filter track fit code package"
 )
+
+message( STATUS "Project Version: ${CMAKE_PROJECT_VERSION}")
+message( STATUS "Commit short hash: ${_build_ver_commit_short}")
+message( STATUS "Commits made since last tag: ${_build_ver_commits_since_tag}")
+
 
 
 # find the ROOT dependency

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,35 @@
 cmake_minimum_required(VERSION 3.9.0)
 
-# always use gcc
+# Check + Enforce build type
+
+set(default_build_type "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui                                                                                                                                                           
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release")
+endif()
+
+if (CMAKE_BUILD_TYPE MATCHES "^(p|P)(rofile|rof)$")
+    message(STATUS "Setting build type to 'Release' instead of '${CMAKE_BUILD_TYPE}'.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE
+        STRING "Choose the type of build." FORCE)
+endif()
+
+
+if (NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release)$")
+    message(STATUS "Setting build type to '${default_build_type}' as neither Release or Debug was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+        STRING "Choose the type of build." FORCE)
+endif()
+
+message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}" )
+
+
+# use gcc where we can
 set(CMAKE_C_COMPILER "gcc")
 set(CMAKE_CXX_COMPILER "g++")
 
@@ -8,43 +37,72 @@ set(CMAKE_CXX_COMPILER "g++")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
-set(CMAKE_CXX_FLAGS "-Wall -Wno-unused-parameter -Wno-unused-local-typedefs -Werror -gdwarf-2 -Werror=return-type -Winit-self -Woverloaded-virtual -ftrapping-math"
-    CACHE STRING "Flags (all configurations)" FORCE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -Og" 
-    CACHE STRING "Debug flags" FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -fno-omit-frame-pointer" 
-    CACHE STRING "Release/Prof flags" FORCE)
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
-endif()
-message( "Build Type: ${CMAKE_BUILD_TYPE}" )
-
+# make sure CMake is able to find ROOT
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
-project (KinKal CXX)
 
-find_package(ROOT REQUIRED COMPONENTS Core RIO Net Hist GenVector MLP Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread Gui)
+# Set project name and version
+project (KinKal 
+    LANGUAGES CXX 
+    VERSION 0.0.1 
+    DESCRIPTION "Kinematic Kalman filter track fit code package"
+)
 
-# include "useful" ROOT headers
+
+# find the ROOT dependency
+find_package(ROOT REQUIRED COMPONENTS 
+        Core RIO Net Hist GenVector MLP Graf Graf3d Gpad Tree 
+        Rint Postscript Matrix Physics MathCore Thread Gui)
+
+# include "useful" ROOT cmake functions
+# which are useful for building dictionaries
 include(${ROOT_USE_FILE})
 
-include_directories(${PROJECT_SOURCE_DIR})
+# set RPATH options
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+# output shared libraries and executables in lib/ and bin/
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
+# enable tests
 enable_testing()
 
+# compiler flags
+add_compile_options(
+    # flags applied to ALL build types
+    "-Wall" 
+    "-Wno-unused-parameter" 
+    "-Wno-unused-local-typedefs" 
+    "-Werror" 
+    "-gdwarf-2" 
+    "-Werror=return-type" 
+    "-Winit-self" 
+    "-Woverloaded-virtual" 
+    "-ftrapping-math"
+
+    # debug flags
+    "$<$<CONFIG:DEBUG>:-Og;-g>"
+
+    # release flags
+    "$<$<CONFIG:RELEASE>:-O3;-DNDEBUG;-fno-omit-frame-pointer>"
+)
+
+# add shared library targets
 add_subdirectory(MatEnv)
 add_subdirectory(KinKal)
 add_subdirectory(UnitTests)
 
+# install rules
+include(GNUInstallDirs)
 
-message ("Writing setup.sh...")
+install(TARGETS KinKal MatEnv
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+message (STATUS "Writing setup.sh...")
 
 file(WRITE ${PROJECT_BINARY_DIR}/setup.sh "
 #
@@ -58,7 +116,10 @@ fi
 export PACKAGE_SOURCE=${CMAKE_SOURCE_DIR}
 export DEBUG_LEVEL=${CMAKE_BUILD_TYPE}
 source \${PACKAGE_SOURCE}/setup.sh
+
+# Linux: 
 export LD_LIBRARY_PATH=\${PWD}/lib:\${LD_LIBRARY_PATH}
+
 # MacOS:
 export DYLD_FALLBACK_LIBRARY_PATH=\${PWD}/lib:\${ROOT_LIB}:\${DYLD_FALLBACK_LIBRARY_PATH}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(GIT_FOUND)
   )
   message( STATUS "git describes this revision as: ${_build_version}")
 
-  if (_build_version MATCHES "^v([0-9]+)\_([0-9]+)\_([0-9]+)\-([0-9]+)\-([a-z0-9]+)$")
+  if (_build_version MATCHES "^.*([0-9]+)[._]([0-9]+)[._]([0-9]+)\\-([0-9]+)\\-([a-z0-9]+)$")
     set (_build_ver_maj ${CMAKE_MATCH_1})
     set (_build_ver_min ${CMAKE_MATCH_2})
     set (_build_ver_patch ${CMAKE_MATCH_3})
@@ -85,7 +85,6 @@ project (KinKal
 message( STATUS "Project Version: ${CMAKE_PROJECT_VERSION}")
 message( STATUS "Commits made since last tag: ${_build_ver_commits_since_tag}")
 message( STATUS "Commit short hash: ${_build_ver_commit_short}")
-
 
 
 # find the ROOT dependency

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,13 +41,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
 
-# find git information
+# versioning
 
+set (_build_ver_maj 0)
+set (_build_ver_min 0)
+set (_build_ver_patch 0)
+set (_build_ver_commits_since_tag 0)
+set (_build_ver_commit_short 0)
+
+# find git information
 find_package(Git)
+
 if(GIT_FOUND)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} describe
-    WORKING_DIRECTORY "${local_dir}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     OUTPUT_VARIABLE _build_version
     ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -64,11 +72,6 @@ if(GIT_FOUND)
   endif()
 else()
   message( STATUS "Git not found!")
-  set (_build_ver_maj 0)
-  set (_build_ver_min 0)
-  set (_build_ver_patch 0)
-  set (_build_ver_commits_since_tag 0)
-  set (_build_ver_commit_short 0)
 endif()
 
 
@@ -80,8 +83,8 @@ project (KinKal
 )
 
 message( STATUS "Project Version: ${CMAKE_PROJECT_VERSION}")
-message( STATUS "Commit short hash: ${_build_ver_commit_short}")
 message( STATUS "Commits made since last tag: ${_build_ver_commits_since_tag}")
+message( STATUS "Commit short hash: ${_build_ver_commit_short}")
 
 
 

--- a/KinKal/CMakeLists.txt
+++ b/KinKal/CMakeLists.txt
@@ -1,5 +1,34 @@
-file( GLOB KinKal_LIB_SOURCES *.cc )
-file( GLOB KinKal_LIB_HEADERS *.hh )
 
-add_library(KinKal SHARED ${KinKal_LIB_SOURCES} ${KinKal_LIB_HEADERS} )
-target_link_libraries(KinKal ${ROOT_LIBRARIES}) 
+# Explicitly list source files in this shared library
+# When a new source file is added, it must be added to this list.
+
+# Globbing is not recommended, see: https://cmake.org/cmake/help/v3.12/command/file.html#filesystem
+
+# you can regenerate this list easily by running in this directory: ls -1 *.cc
+add_library(KinKal SHARED 
+    BFieldMap.cc
+    CentralHelix.cc
+    ClosestApproachData.cc
+    Config.cc
+    FitStatus.cc
+    KinematicLine.cc
+    Line.cc
+    LoopHelix.cc
+    LRAmbig.cc
+    Parameters.cc
+    ParticleState.cc
+    POCAUtil.cc
+    StrawMat.cc
+    TimeDir.cc
+    TimeRange.cc
+    Weights.cc
+)
+
+# set top-level directory as include root
+target_include_directories(KinKal PRIVATE ${PROJECT_SOURCE_DIR})
+
+# link this library with ROOT libraries
+target_link_libraries(KinKal ${ROOT_LIBRARIES})
+
+# set shared library version equal to project version
+set_target_properties(KinKal PROPERTIES VERSION ${PROJECT_VERSION})

--- a/MatEnv/CMakeLists.txt
+++ b/MatEnv/CMakeLists.txt
@@ -1,5 +1,23 @@
 
-file( GLOB MATENV_LIB_SOURCES *.cc )
-file( GLOB MATENV_LIB_HEADERS *.hh )
+add_library(MatEnv SHARED 
+    DetMaterial.cc
+    ElmPropObj.cc
+    MatDBInfo.cc
+    MatElementList.cc
+    MatElementObj.cc
+    MatElmDictionary.cc
+    MatIsoDictionary.cc
+    MatIsotopeList.cc
+    MatIsotopeObj.cc
+    MatMaterialList.cc
+    MatMaterialObj.cc
+    MatMtrDictionary.cc
+    MtrPropObj.cc
+    RecoMatFactory.cc
+)
 
-add_library(MatEnv SHARED ${MATENV_LIB_SOURCES} ${MATENV_LIB_HEADERS} )
+# set top-level directory as include root
+target_include_directories(MatEnv PRIVATE ${PROJECT_SOURCE_DIR})
+
+# set shared library version equal to project version
+set_target_properties(MatEnv PROPERTIES VERSION ${PROJECT_VERSION})

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -1,30 +1,71 @@
+# List of unit test sources
+# ls -1 *_unit.cc
+
+set( TEST_SOURCE_FILES
+    CentralHelixBFieldTest_unit.cc
+    CentralHelixDerivs_unit.cc
+    CentralHelixFitTest_unit.cc
+    CentralHelixHitTest_unit.cc
+    CentralHelixPKTrajTest_unit.cc
+    CentralHelixTPocaTest_unit.cc
+    CentralHelix_unit.cc
+    KinematicLineBFieldTest_unit.cc
+    KinematicLineDerivs_unit.cc
+    KinematicLineFitTest_unit.cc
+    KinematicLineHitTest_unit.cc
+    KinematicLinePKTrajTest_unit.cc
+    KinematicLineTPocaTest_unit.cc
+    KinematicLine_unit.cc
+    LoopHelixBFieldTest_unit.cc
+    LoopHelixDerivs_unit.cc
+    LoopHelixFitTest_unit.cc
+    LoopHelixHitTest_unit.cc
+    LoopHelixPKTrajTest_unit.cc
+    LoopHelixTPocaTest_unit.cc
+    LoopHelix_unit.cc
+    MatEnv_unit.cc
+)
+
 
 
 # generate root dictionary
-ROOT_GENERATE_DICTIONARY(G__Dict HitInfo.hh BFieldInfo.hh ParticleTrajectoryInfo.hh MaterialInfo.hh NOINSTALL
+
+ROOT_GENERATE_DICTIONARY(G__Dict 
+    # headers to include in ROOT dictionary
+    HitInfo.hh 
+    BFieldInfo.hh 
+    ParticleTrajectoryInfo.hh 
+    MaterialInfo.hh 
+    NOINSTALL
     LINKDEF LinkDef.h
 )
-add_library(UnitTests SHARED  G__Dict)
-target_include_directories(UnitTests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# create shared library with ROOT dict
+add_library(UnitTests SHARED G__Dict)
+
+target_include_directories(UnitTests PRIVATE ${PROJECT_SOURCE_DIR})
+target_include_directories(UnitTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# link ROOT libraries
 target_link_libraries(UnitTests ${ROOT_LIBRARIES})
 
-# find all unit test sources and build an executable for each
-file( GLOB TEST_APP_SOURCES *_unit.cc )
-
-foreach( testsourcefile ${TEST_APP_SOURCES} )
+# Generate unit test targets
+foreach( testsourcefile ${TEST_SOURCE_FILES} )
     # get the name of the unit test from the source path
     # (strip _unit.cc, and the path preceding the basename)
     string( REPLACE "_unit.cc" "" testnamenoext ${testsourcefile} )
     get_filename_component(testname ${testnamenoext} NAME)
 
-    # prepend UnitTest_ to the target name to avoid clashes.
+    # prepend UnitTest_ to the target name to avoid target name clashes,
+    # create the unit test executable:
     add_executable( UnitTest_${testname} ${testsourcefile} )
 
-    # ensure the unit test filename is just its test name
-    set_target_properties( UnitTest_${testname} PROPERTIES OUTPUT_NAME ${testname})
-
+    # add the project root as an include directory
     # link all unit tests to KinKal, MatEnv, and ROOT libraries.
+    target_include_directories(UnitTest_${testname} PRIVATE ${PROJECT_SOURCE_DIR})
     target_link_libraries( UnitTest_${testname} KinKal MatEnv UnitTests ${ROOT_LIBRARIES} )
+
+    # ensure the unit test executable filename is just its test name
+    set_target_properties( UnitTest_${testname} PROPERTIES OUTPUT_NAME ${testname})
 
     # register the target as a test 
     add_test (NAME ${testname} COMMAND UnitTest_${testname} )
@@ -34,4 +75,4 @@ foreach( testsourcefile ${TEST_APP_SOURCES} )
     install( TARGETS UnitTest_${testname}
              RUNTIME DESTINATION bin/ )
  
-endforeach( testsourcefile ${TEST_APP_SOURCES} )
+endforeach( testsourcefile ${TEST_SOURCE_FILES} )


### PR DESCRIPTION
- Enforces two build types: `Release` and `Debug`
  - `prof`, `profile` is corrected to `Release`
  - If no `CMAKE_BUILD_TYPE` is specified, default to `Release`

- Got rid of dated `CMAKE_CXX_FLAGS` usage, which is no longer recommended
- Compiler options are set using cross-platform friendly `add_compile_options` function

- Package directories have explicit lists of `*.cc` files to make sure CMake detects when new `*.cc` files are added
  - file(GLOB ...) is discouraged by CMake developers
  - Easy to regenerate these using `ls -1 *.cc` and copy-paste
  - Comments elaborate on this