### PR TITLE
CMake install rules for headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ add_subdirectory(KinKal)
 add_subdirectory(UnitTests)
 
 # install rules
-install(TARGETS KinKal MatEnv
+install(TARGETS KinKal MatEnv UnitTests
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 # enable tests
 enable_testing()
 
+include(GNUInstallDirs)
+
 # compiler flags
 add_compile_options(
     # flags applied to ALL build types
@@ -133,8 +135,6 @@ add_subdirectory(KinKal)
 add_subdirectory(UnitTests)
 
 # install rules
-include(GNUInstallDirs)
-
 install(TARGETS KinKal MatEnv
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/KinKal/CMakeLists.txt
+++ b/KinKal/CMakeLists.txt
@@ -32,3 +32,51 @@ target_link_libraries(KinKal ${ROOT_LIBRARIES})
 
 # set shared library version equal to project version
 set_target_properties(KinKal PROPERTIES VERSION ${PROJECT_VERSION})
+
+# select which headers to install ls -1 *.hh
+install(FILES
+    BFieldEffect.hh
+    BFieldMap.hh
+    BFieldUtils.hh
+    CentralHelix.hh
+    ClosestApproachData.hh
+    ClosestApproach.hh
+    Config.hh
+    Constraint.hh
+    DetectorHit.hh
+    DetectorXing.hh
+    Effect.hh
+    FitData.hh
+    FitState.hh
+    FitStatus.hh
+    KinematicLine.hh
+    Line.hh
+    LoopHelix.hh
+    LRAmbig.hh
+    Material.hh
+    MaterialXing.hh
+    Measurement.hh
+    MomBasis.hh
+    Parameters.hh
+    ParticleState.hh
+    ParticleTrajectory.hh
+    PieceClosestApproach.hh
+    PieceTrajectory.hh
+    POCAUtil.hh
+    PrintDetail.hh
+    Residual.hh
+    ScintHit.hh
+    StrawHit.hh
+    StrawMat.hh
+    StrawXing.hh
+    TimeDir.hh
+    TimeRange.hh
+    TrackEnd.hh
+    Track.hh
+    Vectors.hh
+    Weights.hh
+    WireCell.hh
+    WireHit.hh
+
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/KinKal
+)

--- a/MatEnv/CMakeLists.txt
+++ b/MatEnv/CMakeLists.txt
@@ -21,3 +21,28 @@ target_include_directories(MatEnv PRIVATE ${PROJECT_SOURCE_DIR})
 
 # set shared library version equal to project version
 set_target_properties(MatEnv PROPERTIES VERSION ${PROJECT_VERSION})
+
+# select which headers to install ls -1 *.hh
+install(FILES
+    BbrCollectionUtils.hh
+    DetMaterial.hh
+    ElmPropObj.hh
+    ErrLog.hh
+    FileFinderInterface.hh
+    MatDBInfo.hh
+    MatElementList.hh
+    MatElementObj.hh
+    MatElmDictionary.hh
+    MaterialInfo.hh
+    MatIsoDictionary.hh
+    MatIsotopeList.hh
+    MatIsotopeObj.hh
+    MatMaterialList.hh
+    MatMaterialObj.hh
+    MatMtrDictionary.hh
+    MtrPropObj.hh
+    PtrLess.hh
+    RecoMatFactory.hh
+
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/MatEnv
+)

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -36,7 +36,6 @@ ROOT_GENERATE_DICTIONARY(G__Dict
     BFieldInfo.hh 
     ParticleTrajectoryInfo.hh 
     MaterialInfo.hh 
-    NOINSTALL
     LINKDEF LinkDef.h
 )
 # create shared library with ROOT dict

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -44,6 +44,10 @@ add_library(UnitTests SHARED G__Dict)
 target_include_directories(UnitTests PRIVATE ${PROJECT_SOURCE_DIR})
 target_include_directories(UnitTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# set shared library version equal to project version
+set_target_properties(UnitTests PROPERTIES VERSION ${PROJECT_VERSION})
+
+
 # link ROOT libraries
 target_link_libraries(UnitTests ${ROOT_LIBRARIES})
 


### PR DESCRIPTION
I forgot to make sure that headers were being properly installed.

I assume something like this will be needed for making the ups product at some stage. Headers get installed into `include/KinKal` or `include/MatEnv` folders at the prefix location. 

You should now be able to install a KinKal release into any directory like this:
```bash

git clone git@github.com:KFTrack/KinKal

# defaults to Release configuration
cmake KinKal -B build -DCMAKE_INSTALL_PREFIX=KinKal_release
cd build
make -j16

# installs binaries (bin/), shared libraries (lib/), and header files (include/)
# inside KinKal_release folder
make install 
```

You can select which headers you specifically want to install per target, but I just included all of them by default.