### PR TITLE
Install headers + clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,30 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-braces-around-statements,readability-misleading-indentation,readability-non-const-parameter'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            roneil
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-braces-around-statements,readability-misleading-indentation,readability-non-const-parameter'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 # make sure CMake is able to find ROOT
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # versioning
 
@@ -173,3 +174,33 @@ export LD_LIBRARY_PATH=\${PWD}/lib:\${LD_LIBRARY_PATH}
 export DYLD_FALLBACK_LIBRARY_PATH=\${PWD}/lib:\${ROOT_LIB}:\${DYLD_FALLBACK_LIBRARY_PATH}
 
 ")
+
+
+# clang tidy
+
+if(ENABLE_CLANG_TIDY)
+
+    find_program(CLANG_TIDY_BIN clang-tidy)
+    find_program(RUN_CLANG_TIDY_BIN run-clang-tidy)
+
+    if(CLANG_TIDY_BIN STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
+        message(FATAL_ERROR "unable to locate clang-tidy")
+    endif()
+
+    if(RUN_CLANG_TIDY_BIN STREQUAL "RUN_CLANG_TIDY_BIN-NOTFOUND")
+        message(FATAL_ERROR "unable to locate run-clang-tidy.py")
+    endif()
+
+    list(APPEND RUN_CLANG_TIDY_BIN_ARGS
+        -p .
+    )
+
+    add_custom_target(
+        tidy
+        COMMAND ${RUN_CLANG_TIDY_BIN} ${RUN_CLANG_TIDY_BIN_ARGS}
+        COMMENT "running clang tidy"
+    )
+
+endif()
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.9.0)
 
 # Check + Enforce build type
-
 set(default_build_type "Release")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -127,6 +126,9 @@ add_compile_options(
     "$<$<CONFIG:RELEASE>:-O3;-DNDEBUG;-fno-omit-frame-pointer>"
 )
 
+# install rules
+include(GNUInstallDirs)
+
 # add shared library targets
 add_subdirectory(MatEnv)
 add_subdirectory(General)
@@ -135,12 +137,19 @@ add_subdirectory(Trajectory)
 add_subdirectory(Fit)
 add_subdirectory(Tests)
 
-# install rules
-include(GNUInstallDirs)
 
-install(TARGETS General Trajectory Detector Fit MatEnv
+install(TARGETS General Trajectory Detector Fit MatEnv Tests
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# install headers
+# Globbing here is fine because it does not influence build behaviour
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/KinKal
+        FILES_MATCHING PATTERN "*.hh" 
+        PATTERN ".git*" EXCLUDE
+)
+
 
 message (STATUS "Writing setup.sh...")
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -30,17 +30,17 @@ set( TEST_SOURCE_FILES
 
 # generate root dictionary
 
-ROOT_GENERATE_DICTIONARY(G__Dict 
+ROOT_GENERATE_DICTIONARY(TestsDict 
     # headers to include in ROOT dictionary
     HitInfo.hh 
     BFieldInfo.hh 
     ParticleTrajectoryInfo.hh 
     MaterialInfo.hh 
-    NOINSTALL
+
     LINKDEF LinkDef.h
 )
 # create shared library with ROOT dict
-add_library(Tests SHARED G__Dict)
+add_library(Tests SHARED TestsDict)
 
 target_include_directories(Tests PRIVATE ${PROJECT_SOURCE_DIR}/..)
 target_include_directories(Tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
- install all `*.hh` files preserving directory structure into `CMAKE_INSTALL_PREFIX/include/KinKal/<MatEnv/General/Fit/..>/<headerfile>.hh`

- option to create a `clang-tidy` target (default off). Can be made to work on `macOS` like this:
```
# only need to run once
brew install llvm
ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
ln -s "$(brew --prefix llvm)/share/clang/run-clang-tidy.py" "/usr/local/bin/run-clang-tidy"

mkdir build && cd build
cmake ../KinKal -DENABLE_CLANG_TIDY=ON
make tidy
```

- a release of KinKal can be installed to a directory like this:
```
mkdir build && cd build
cmake ../KinKal -DCMAKE_INSTALL_PREFIX=path/to/install/location
make -j8
make install
```