### PR TITLE
use native cmake support for clang tidy rather than run-clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,15 @@ add_compile_options(
 # install rules
 include(GNUInstallDirs)
 
+
+# clang tidy
+
+if(ENABLE_CLANG_TIDY)
+    set(CMAKE_CXX_CLANG_TIDY clang-tidy) 
+endif()
+
+
+
 # add shared library targets
 add_subdirectory(MatEnv)
 add_subdirectory(General)
@@ -174,33 +183,5 @@ export LD_LIBRARY_PATH=\${PWD}/lib:\${LD_LIBRARY_PATH}
 export DYLD_FALLBACK_LIBRARY_PATH=\${PWD}/lib:\${ROOT_LIB}:\${DYLD_FALLBACK_LIBRARY_PATH}
 
 ")
-
-
-# clang tidy
-
-if(ENABLE_CLANG_TIDY)
-
-    find_program(CLANG_TIDY_BIN clang-tidy)
-    find_program(RUN_CLANG_TIDY_BIN run-clang-tidy)
-
-    if(CLANG_TIDY_BIN STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
-        message(FATAL_ERROR "unable to locate clang-tidy")
-    endif()
-
-    if(RUN_CLANG_TIDY_BIN STREQUAL "RUN_CLANG_TIDY_BIN-NOTFOUND")
-        message(FATAL_ERROR "unable to locate run-clang-tidy.py")
-    endif()
-
-    list(APPEND RUN_CLANG_TIDY_BIN_ARGS
-        -p .
-    )
-
-    add_custom_target(
-        tidy
-        COMMAND ${RUN_CLANG_TIDY_BIN} ${RUN_CLANG_TIDY_BIN_ARGS}
-        COMMENT "running clang tidy"
-    )
-
-endif()
 
 


### PR DESCRIPTION
Removes dependency on `run-clang-tidy`. Takes advantage of native cmake support