### PR TITLE
use unannotated tags for git describe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ find_package(Git)
 
 if(GIT_FOUND)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe
+    COMMAND ${GIT_EXECUTABLE} describe --tags
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     OUTPUT_VARIABLE _build_version
     ERROR_QUIET


### PR DESCRIPTION
Stops `git describe` from ignoring the `v0.1.0` tag.