### PR TITLE
GitHub actions to replace travis

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,31 @@
+jobs:
+  build-test-kinkal:
+    name: Build+Test (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.7"]
+        build-type: ["Debug", "Release"]
+    steps:
+    
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+      - name: Conda info
+        shell: bash -l {0}
+        run: conda info
+      - name: Conda: Install Dependencies
+        shell: bash
+        run: conda install -c conda-forge cxx-compiler root cmake
+      - uses: actions/checkout@v2
+        with:
+          path: "KinKal-src"
+      - name: Build ({{ matrix.build-type }})
+        run: |
+          cmake -S KinKal-src -B KinKal_{{ matrix.build-type }} -DCMAKE_BUILD_TYPE={{ matrix.build-type }}
+          make -C KinKal_{{ matrix.build-type }}
+      - name: Test ({{ matrix.build-type }})
+        run: make -C KinKal_{{ matrix.build-type }} test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,13 +4,14 @@ on: [push, pull_request]
 
 jobs:
   build-test-kinkal:
-    name: Build+Test (${{ matrix.build-type }}, ${{ matrix.os }}, ${{ matrix.python-version }})
+    name: Build+Test (${{ matrix.build-type }}, ${{ matrix.os }}, root ${{ matrix.root-version }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7"]
+        root-version: ["6.22.6"]
         build-type: ["Debug", "Release"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
@@ -24,7 +25,7 @@ jobs:
         
       - name: Conda/Mamba Install
         shell: bash -l {0}
-        run: mamba install -c conda-forge cxx-compiler root cmake
+        run: mamba install -c conda-forge cxx-compiler root=${{ matrix.root-version }} cmake
         
       - uses: actions/checkout@v2
         

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,19 +17,25 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+
       - name: Conda info
         shell: bash -l {0}
         run: conda info
+        
       - name: Conda Install
         shell: bash -l {0}
         run: conda install -c conda-forge cxx-compiler root cmake
+        
       - uses: actions/checkout@v2
+        
       - name: Build (${{ matrix.build-type }})
         shell: bash -l {0}
+        
         run: |
           cd ..
           cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-          make -C KinKal_${{ matrix.build-type }}
+          make -C KinKal_${{ matrix.build-type }} -j4
+          
       - name: Test (${{ matrix.build-type }})
         shell: bash -l {0}
-        run: cd .. && make -C KinKal_${{ matrix.build-type }} test
+        run: cd .. && env CTEST_OUTPUT_ON_FAILURE=1 make -C KinKal_${{ matrix.build-type }} test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,13 +21,15 @@ jobs:
         shell: bash -l {0}
         run: conda info
       - name: Conda Install
-        shell: bash
+        shell: bash -l {0}
         run: conda install -c conda-forge cxx-compiler root cmake
       - uses: actions/checkout@v2
       - name: Build (${{ matrix.build-type }})
+        shell: bash -l {0}
         run: |
           cd ..
           cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
           make -C KinKal_${{ matrix.build-type }}
       - name: Test (${{ matrix.build-type }})
+        shell: bash -l {0}
         run: make -C KinKal_${{ matrix.build-type }} test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-test-kinkal:
-    name: Build+Test (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Build+Test (${{ matrix.python-version }}, ${{ matrix.os }}, ${{ matrix.build-type }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,11 +24,9 @@ jobs:
         shell: bash
         run: conda install -c conda-forge cxx-compiler root cmake
       - uses: actions/checkout@v2
-        with:
-          path: "KinKal-src"
-      - name: Build ({{ matrix.build-type }})
+      - name: Build (${{ matrix.build-type }})
         run: |
-          cmake -S KinKal-src -B KinKal_{{ matrix.build-type }} -DCMAKE_BUILD_TYPE={{ matrix.build-type }}
-          make -C KinKal_{{ matrix.build-type }}
-      - name: Test ({{ matrix.build-type }})
-        run: make -C KinKal_{{ matrix.build-type }} test
+          cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+          make -C KinKal_${{ matrix.build-type }}
+      - name: Test (${{ matrix.build-type }})
+        run: make -C KinKal_${{ matrix.build-type }} test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,3 +1,7 @@
+name: "Build + Test KinKal"
+
+on: [push, pull_request]
+
 jobs:
   build-test-kinkal:
     name: Build+Test (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -9,7 +13,6 @@ jobs:
         python-version: ["3.7"]
         build-type: ["Debug", "Release"]
     steps:
-    
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -17,7 +20,7 @@ jobs:
       - name: Conda info
         shell: bash -l {0}
         run: conda info
-      - name: Conda: Install Dependencies
+      - name: Conda Install
         shell: bash
         run: conda install -c conda-forge cxx-compiler root cmake
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,4 +32,4 @@ jobs:
           make -C KinKal_${{ matrix.build-type }}
       - name: Test (${{ matrix.build-type }})
         shell: bash -l {0}
-        run: make -C KinKal_${{ matrix.build-type }} test
+        run: cd .. && make -C KinKal_${{ matrix.build-type }} test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,16 +15,16 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-
+          mamba-version: "*"
+          channels: conda-forge,defaults
       - name: Conda info
         shell: bash -l {0}
         run: conda info
         
-      - name: Conda Install
+      - name: Conda/Mamba Install
         shell: bash -l {0}
-        run: conda install -c conda-forge cxx-compiler root cmake
+        run: mamba install -c conda-forge cxx-compiler root cmake
         
       - uses: actions/checkout@v2
         

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-test-kinkal:
-    name: Build+Test (${{ matrix.python-version }}, ${{ matrix.os }}, ${{ matrix.build-type }})
+    name: Build+Test (${{ matrix.build-type }}, ${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build (${{ matrix.build-type }})
         run: |
+          cd ..
           cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
           make -C KinKal_${{ matrix.build-type }}
       - name: Test (${{ matrix.build-type }})

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: "Build + Test KinKal"
+name: "KinKal"
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Hello! 

I noticed Travis CI stopped working. GitHub actions can be used instead (it is also free for public repositories) and can be used to do the same automated testing. It also "just works" once this file is added to the right place.

ROOT comes from conda-forge instead of depending on cvmfs / cern LCG views. 

You can be specific about which version (or versions) of ROOT you test against by adding / removing version strings from the `root-version` list in the `matrix` block. At the moment it tests against ROOT 6.22.6.

An example run looks like this: https://github.com/ryuwd/KinKal/runs/1709950357?check_suite_focus=true