### PR TITLE
Clang-Tidy + colour in log files

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,15 @@
 name: "KinKal"
 
 on: [push, pull_request]
-
+defaults:
+  run:
+    shell: bash -l {0}
+env:
+  CLICOLOR_FORCE: 1
+  
 jobs:
   build-test-kinkal:
-    name: Build+Test (${{ matrix.build-type }}, ${{ matrix.os }}, root ${{ matrix.root-version }}, py${{ matrix.python-version }})
+    name: Tests (${{ matrix.build-type }}, ${{ matrix.os }}, root ${{ matrix.root-version }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -13,30 +18,31 @@ jobs:
         python-version: ["3.7"]
         root-version: ["6.22.6"]
         build-type: ["Debug", "Release"]
+
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
-          channels: conda-forge,defaults
+          channels: defaults,conda-forge
+      
       - name: Conda info
-        shell: bash -l {0}
         run: conda info
         
       - name: Conda/Mamba Install
-        shell: bash -l {0}
-        run: mamba install -c conda-forge cxx-compiler root=${{ matrix.root-version }} cmake
+        run: mamba install -c conda-forge cxx-compiler root=${{ matrix.root-version }} cmake clang-tools
         
       - uses: actions/checkout@v2
         
+      - name: CMake (${{ matrix.build-type }})
+        run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON
+      
       - name: Build (${{ matrix.build-type }})
-        shell: bash -l {0}
-        
-        run: |
-          cd ..
-          cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-          make -C KinKal_${{ matrix.build-type }} -j4
+        run: cd .. && make -C KinKal_${{ matrix.build-type }} -j8
           
-      - name: Test (${{ matrix.build-type }})
-        shell: bash -l {0}
+      - name: Run tests
         run: cd .. && env CTEST_OUTPUT_ON_FAILURE=1 make -C KinKal_${{ matrix.build-type }} test
+        
+      - name: Run clang-tidy
+        run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }}_ClangTidy -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON -DENABLE_CLANG_TIDY=ON && make -C KinKal_${{ matrix.build-type }}_ClangTidy -j8
+        

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ add_compile_options(
     "-Winit-self" 
     "-Woverloaded-virtual" 
     "-ftrapping-math"
+    "-fdiagnostics-color=always"
 
     # debug flags
     "$<$<CONFIG:DEBUG>:-O0;-g>"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/KFTrack/KinKal.svg?branch=master)](https://travis-ci.org/KFTrack/KinKal)
+[![Build Status](https://github.com/KFTrack/KinKal/workflows/KinKal/badge.svg)](https://github.com/KFTrack/KinKal/actions)
 
 # Kinematic Kalman filter track fit code package
 
@@ -75,7 +75,7 @@ cd build_profile
 
 ### CMake
 
-3. Generate the build system, and build
+3. Run `cmake`, and build with `make`
 
 ```bash
 
@@ -92,11 +92,24 @@ make test
 Test programs will be built in the `bin/` directory. Run them with `--help` in the `build` directory to get a list of run parameters.
 
 ### Build FAQ
+### Running `clang-tidy`
+
+Make sure `clang-tidy` is installed, and add an extra argument to the `cmake` command.
+
+```bash
+mkdir build_clangtidy 
+cd build_clangtidy
+cmake ../KinKal -DCMAKE_BUILD_TYPE=[Release/Debug] -DENABLE_CLANG_TIDY=ON
+make -j <jobs to run>
+```
+
+The code will appear to compile as normal, although in this case `clang-tidy` is actually checking the code for problems. No warnings or errors mean that no problems were found.
+
 #### (MacOS) Brew not working
-The build tries to find ROOT with the `root-config` executable. You should ensure before building that `brew` added the ROOT `bin/` directory correctly to the `$PATH` environment variable. Sometimes re-installing the package can fix the issue.
+The build tries to find ROOT using `cmake`. You should ensure before building that `brew` added the ROOT `bin/` directory correctly to the `$PATH` environment variable. Sometimes re-installing the package can fix the issue.
 
 #### Problems building against a ROOT binary or manually compiled release
-You should make sure to source the `<root_location>/bin/thisroot.sh` shell script before building. This sets all the necessary environment variables needed by KinKal.
+If not installed via a package manager, you should make sure to source the `<root_location>/bin/thisroot.sh` shell script before building.
 ```bash
 
 source <ROOT>/bin/thisroot.sh
@@ -104,3 +117,5 @@ source <ROOT>/bin/thisroot.sh
 ```
 
 The ROOT binaries need to be compiled with C++17 (`-std=c++17`) support.
+
+


### PR DESCRIPTION
Hello again!

Hope all is well (and a very belated happy new year!) Following my last PR I thought I'd clean up a bit and add a couple of small adjustments for completeness:

Logs have colour enabled now (as Travis did) and are easier to read
<img width="713" alt="Screenshot 2021-01-17 at 20 45 24" src="https://user-images.githubusercontent.com/56410978/104855494-09429880-5905-11eb-8420-58fe428b2b42.png">

Clang-tidy runs now as an extra step
<img width="1359" alt="Screenshot 2021-01-17 at 20 45 55" src="https://user-images.githubusercontent.com/56410978/104855500-13649700-5905-11eb-9a3a-86a46e1528c5.png">


Example output here: 
https://github.com/ryuwd/KinKal/runs/1717884942?check_suite_focus=true

Clang-tidy runs in every job after a successful build + test run. You can see the log output by expanding the "Run clang-tidy" item: 
<img width="293" alt="Screenshot 2021-01-17 at 20 49 27" src="https://user-images.githubusercontent.com/56410978/104855608-9dacfb00-5905-11eb-8c7f-037cc6413b59.png">

Warnings from clang-tidy don't cause checks to fail.
