### PR TITLE
actions cleanup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter,-bugprone-exception-escape'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,12 +20,23 @@ jobs:
         build-type: ["Debug", "Release"]
 
     steps:
+      - name: Cache conda
+        uses: actions/cache@v1
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          # This will be necessary to update e.g. the version of cmake, cxx-compiler, or clang-tools that is used
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.root-version }}-${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
           channels: defaults,conda-forge
-      
+          channel-priority: strict
+          use-only-tar-bz2: true
       - name: Conda info
         run: conda info
         
@@ -33,7 +44,8 @@ jobs:
         run: mamba install -c conda-forge cxx-compiler root=${{ matrix.root-version }} cmake clang-tools
         
       - uses: actions/checkout@v2
-        
+        with:
+          fetch-depth: 0        
       - name: CMake (${{ matrix.build-type }})
         run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON
       
@@ -44,5 +56,11 @@ jobs:
         run: cd .. && env CTEST_OUTPUT_ON_FAILURE=1 make -C KinKal_${{ matrix.build-type }} test
         
       - name: Run clang-tidy
-        run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }}_ClangTidy -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON -DENABLE_CLANG_TIDY=ON && make -C KinKal_${{ matrix.build-type }}_ClangTidy -j8
-        
+        if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
+        run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }}_ClangTidy -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON -DENABLE_CLANG_TIDY_WITH_FIXES=ON && make -C KinKal_${{ matrix.build-type }}_ClangTidy -j8 && cd KinKal
+
+      - name: suggester / clang-tidy
+        if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: clang-tidy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,17 +47,32 @@ jobs:
         with:
           fetch-depth: 0        
       - name: CMake (${{ matrix.build-type }})
-        run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON
+        run: |
+          cd ..
+          cmake -S KinKal -B KinKal_${{ matrix.build-type }} \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DCMAKE_COLOR_MAKEFILE=ON
       
       - name: Build (${{ matrix.build-type }})
-        run: cd .. && make -C KinKal_${{ matrix.build-type }} -j8
-          
+        run: |
+          cd ../KinKal_${{ matrix.build-type }}
+          make -j8
+
       - name: Run tests
-        run: cd .. && env CTEST_OUTPUT_ON_FAILURE=1 make -C KinKal_${{ matrix.build-type }} test
+        run: |
+          cd ../KinKal_${{ matrix.build-type }}
+          env CTEST_OUTPUT_ON_FAILURE=1 make test
         
       - name: Run clang-tidy
-        if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}
-        run: cd .. && cmake -S KinKal -B KinKal_${{ matrix.build-type }}_ClangTidy -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_COLOR_MAKEFILE=ON -DENABLE_CLANG_TIDY_WITH_FIXES=ON && make -C KinKal_${{ matrix.build-type }}_ClangTidy -j8 && cd KinKal
+        if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' }}
+        run: |
+          cd ..
+          cmake -S KinKal -B KinKal_${{ matrix.build-type }}_ClangTidy \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DCMAKE_COLOR_MAKEFILE=ON \
+                -DENABLE_CLANG_TIDY_WITH_FIXES=ON 
+          cd KinKal_${{ matrix.build-type }}_ClangTidy
+          make -j8
 
       - name: suggester / clang-tidy
         if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ add_compile_options(
     "-Woverloaded-virtual" 
     "-ftrapping-math"
     "-fdiagnostics-color=always"
-    "-Wshadow"
+#    "-Wshadow"
 
     # debug flags
     "$<$<CONFIG:DEBUG>:-O0;-g>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(GIT_FOUND)
   )
   message( STATUS "git describes this revision as: ${_build_version}")
 
-  if (_build_version MATCHES  "^[vV]?([0-9]+)[._]([0-9]+)[._]([0-9]+)(.+)$")
+  if (_build_version MATCHES  "^[vV]?([0-9]+)[._]([0-9]+)[._]([0-9]+)(.*)$")
     set (_build_ver_maj ${CMAKE_MATCH_1})
     set (_build_ver_min ${CMAKE_MATCH_2})
     set (_build_ver_patch ${CMAKE_MATCH_3})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(GIT_FOUND)
   )
   message( STATUS "git describes this revision as: ${_build_version}")
 
-if (_build_version MATCHES  "^[vV]?([0-9]+)[._]([0-9]+)[._]([0-9]+)([A-Za-z0-9_]*)$")
+  if (_build_version MATCHES  "^[vV]?([0-9]+)[._]([0-9]+)[._]([0-9]+)(.+)$")
     set (_build_ver_maj ${CMAKE_MATCH_1})
     set (_build_ver_min ${CMAKE_MATCH_2})
     set (_build_ver_patch ${CMAKE_MATCH_3})
@@ -122,6 +122,7 @@ add_compile_options(
     "-Woverloaded-virtual" 
     "-ftrapping-math"
     "-fdiagnostics-color=always"
+    "-Wshadow"
 
     # debug flags
     "$<$<CONFIG:DEBUG>:-O0;-g>"
@@ -137,7 +138,11 @@ include(GNUInstallDirs)
 # clang tidy
 
 if(ENABLE_CLANG_TIDY)
-    set(CMAKE_CXX_CLANG_TIDY clang-tidy) 
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy") 
+endif()
+
+if(ENABLE_CLANG_TIDY_WITH_FIXES)
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-fix") 
 endif()
 
 


### PR DESCRIPTION
- Clang-tidy now only runs on Linux Release builds (saves runner minutes)
- conda environments are cached to also save time
- `with:fetch-depth: 0` added to see if that makes release tags available in the CI builds
- clang-tidy fix suggestions are added as review comments to pull requests (see https://github.com/ryuwd/KinKal/pull/41#pullrequestreview-616798131)

I attempted to enable `-Wshadow` but this revealed a few occurences of shadowing in `MatEnv`, `Detector` packages, so I left that out