### PR TITLE
Unit test coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,10 +65,13 @@ jobs:
           
           # test coverage report
           if [ "${{ matrix.build-type }}" = "Debug" ]; then
+            mamba install -c conda-forge -y gcovr
+
             if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-              mamba install -c conda-forge -y gcovr
               gcovr -r ../KinKal . --xml -o coverage.xml
-              # --html --html-details -o test-coverage.html
+            fi
+            if [ "${{ matrix.os }}" = "macos-latest" ]; then
+              gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"
             fi
           fi
       - name: Upload coverage

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -83,11 +83,10 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
-          files: ../KinKal_${{ matrix.build-type }}/coverage.xml # optional
-          flags: unittests # optional
-          name: codecov-umbrella # optional
-          verbose: true # optional (default = false)
-      
+          files: ../KinKal_${{ matrix.build-type }}/coverage.xml
+          flags: unittests 
+          name: codecov-umbrella
+
       - name: Run clang-tidy
         if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,22 +70,24 @@ jobs:
         run: |
           cd ../KinKal_${{ matrix.build-type }}
           env CTEST_OUTPUT_ON_FAILURE=1 make test
-          
-          # test coverage report
-          if [ "${{ matrix.build-type }}" = "Debug" ]; then
-            if [ "${{ matrix.os }}" = "macos-latest" ]; then
-              mamba install -c conda-forge -y gcovr --exclude-directories Tests
-              gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"
 
-              make coverage
-            fi
-          fi
+      - name: Create coverage report
+        run: |
+          cd ../KinKal_${{ matrix.build-type }}
+          mamba install -c conda-forge -y gcovr
+
+          make coverage
+          gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"  --exclude-directories Tests
+        
+        if: ${{ matrix.build-type == 'Debug' && matrix.os == 'macos-latest' }}
+
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
           files: ../KinKal_${{ matrix.build-type }}/coverage.xml
           flags: unittests
           name: codecov-umbrella
+        if: ${{ matrix.build-type == 'Debug' && matrix.os == 'macos-latest' }}
 
       - name: Run clang-tidy
         if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,10 +76,9 @@ jobs:
             if [ "${{ matrix.os }}" = "macos-latest" ]; then
               mamba install -c conda-forge -y gcovr
               gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"
+
+              make coverage
             fi
-
-            make coverage
-
           fi
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -74,7 +74,7 @@ jobs:
           # test coverage report
           if [ "${{ matrix.build-type }}" = "Debug" ]; then
             if [ "${{ matrix.os }}" = "macos-latest" ]; then
-              mamba install -c conda-forge -y gcovr
+              mamba install -c conda-forge -y gcovr --exclude-directories Tests
               gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"
 
               make coverage
@@ -84,7 +84,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           files: ../KinKal_${{ matrix.build-type }}/coverage.xml
-          flags: unittests 
+          flags: unittests
           name: codecov-umbrella
 
       - name: Run clang-tidy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,16 @@ jobs:
         run: |
           cd ../KinKal_${{ matrix.build-type }}
           env CTEST_OUTPUT_ON_FAILURE=1 make test
-        
+          
+          # test coverage report
+          if [ "${{ matrix.build-type }}" = "Debug" ]; then
+            if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+              mamba install -c conda-forge -y gcovr
+              gcovr -r ../KinKal . 
+              # --html --html-details -o test-coverage.html
+            fi
+          fi
+
       - name: Run clang-tidy
         if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,9 +49,17 @@ jobs:
       - name: CMake (${{ matrix.build-type }})
         run: |
           cd ..
+          ENABLE_COVERAGE=""
+          
+          if [ "${{ matrix.build-type }}" = "Debug" ]; then
+            if [ "${{ matrix.os }}" = "macos-latest" ]; then
+              ENABLE_COVERAGE="-DCOVERAGE=ON"
+            fi
+          fi
+
           cmake -S KinKal -B KinKal_${{ matrix.build-type }} \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-                -DCMAKE_COLOR_MAKEFILE=ON
+                -DCMAKE_COLOR_MAKEFILE=ON ${ENABLE_COVERAGE}
       
       - name: Build (${{ matrix.build-type }})
         run: |
@@ -65,11 +73,8 @@ jobs:
           
           # test coverage report
           if [ "${{ matrix.build-type }}" = "Debug" ]; then
-            mamba install -c conda-forge -y gcovr
-            if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-              gcovr -r ../KinKal . --xml -o coverage.xml
-            fi
             if [ "${{ matrix.os }}" = "macos-latest" ]; then
+              mamba install -c conda-forge -y gcovr
               gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"
             fi
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,13 +66,15 @@ jobs:
           # test coverage report
           if [ "${{ matrix.build-type }}" = "Debug" ]; then
             mamba install -c conda-forge -y gcovr
-
             if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
               gcovr -r ../KinKal . --xml -o coverage.xml
             fi
             if [ "${{ matrix.os }}" = "macos-latest" ]; then
               gcovr -r ../KinKal . --xml -o coverage.xml --gcov-executable "llvm-cov gcov"
             fi
+
+            make coverage
+
           fi
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,11 +67,18 @@ jobs:
           if [ "${{ matrix.build-type }}" = "Debug" ]; then
             if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
               mamba install -c conda-forge -y gcovr
-              gcovr -r ../KinKal . 
+              gcovr -r ../KinKal . --xml -o coverage.xml
               # --html --html-details -o test-coverage.html
             fi
           fi
-
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          files: ../KinKal_${{ matrix.build-type }}/coverage.xml # optional
+          flags: unittests # optional
+          name: codecov-umbrella # optional
+          verbose: true # optional (default = false)
+      
       - name: Run clang-tidy
         if: ${{ matrix.build-type == 'Release' && matrix.os == 'ubuntu-latest' }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,20 @@ if(ENABLE_CLANG_TIDY_WITH_FIXES)
 endif()
 
 if (CMAKE_BUILD_TYPE MATCHES "^Debug$")
-  link_libraries(-lgcov) # gcov symbols
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # using Clang / LLVM
+    link_libraries(-fprofile-instr-generate)
+    add_custom_target(coverage
+      COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    )
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    link_libraries(-lgcov) # gcov symbols
+    add_custom_target(coverage
+      COMMAND gcovr -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    )
+  endif()
 endif()
 
 # add shared library targets
@@ -170,6 +183,10 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/"
         PATTERN ".git*" EXCLUDE
 )
 
+add_custom_target(coverage
+  COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+
+)
 
 message (STATUS "Writing setup.sh...")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(ENABLE_CLANG_TIDY_WITH_FIXES)
 endif()
 
 if (CMAKE_BUILD_TYPE MATCHES "^Debug$")
-  link_libraries(-fprofile-arcs) # gcov symbols
+  link_libraries(-lgcov) # gcov symbols
 endif()
 
 # add shared library targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,10 +183,6 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/"
         PATTERN ".git*" EXCLUDE
 )
 
-add_custom_target(coverage
-  COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
-
-)
 
 message (STATUS "Writing setup.sh...")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,13 +152,13 @@ if (CMAKE_BUILD_TYPE MATCHES "^Debug$")
       # using Clang / LLVM
       link_libraries(-fprofile-instr-generate)
       add_custom_target(coverage
-        COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+        COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s --exclude-directories Tests
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
       )
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       link_libraries(-lgcov) # gcov symbols
       add_custom_target(coverage
-        COMMAND gcovr -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+        COMMAND gcovr -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s --exclude-directories Tests
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
       )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,9 @@ if(ENABLE_CLANG_TIDY_WITH_FIXES)
     set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-fix") 
 endif()
 
-
+if (CMAKE_BUILD_TYPE MATCHES "^Debug$")
+  link_libraries(-fprofile-arcs) # gcov symbols
+endif()
 
 # add shared library targets
 add_subdirectory(MatEnv)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ add_compile_options(
 #    "-Wshadow"
 
     # debug flags
-    "$<$<CONFIG:DEBUG>:-O0;-g;-fprofile-arcs;-ftest-coverage>"
+    "$<$<CONFIG:DEBUG>:-O0;-g>"
 
     # release flags
     "$<$<CONFIG:RELEASE>:-O3;-DNDEBUG;-fno-omit-frame-pointer>"
@@ -146,19 +146,22 @@ if(ENABLE_CLANG_TIDY_WITH_FIXES)
 endif()
 
 if (CMAKE_BUILD_TYPE MATCHES "^Debug$")
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    # using Clang / LLVM
-    link_libraries(-fprofile-instr-generate)
-    add_custom_target(coverage
-      COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    )
-  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    link_libraries(-lgcov) # gcov symbols
-    add_custom_target(coverage
-      COMMAND gcovr -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    )
+  if (COVERAGE)
+    add_compile_options("-fprofile-arcs" "-ftest-coverage")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      # using Clang / LLVM
+      link_libraries(-fprofile-instr-generate)
+      add_custom_target(coverage
+        COMMAND gcovr --gcov-executable "llvm-cov gcov" -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      )
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      link_libraries(-lgcov) # gcov symbols
+      add_custom_target(coverage
+        COMMAND gcovr -r ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR} -s
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      )
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ add_compile_options(
 #    "-Wshadow"
 
     # debug flags
-    "$<$<CONFIG:DEBUG>:-O0;-g>"
+    "$<$<CONFIG:DEBUG>:-O0;-g;-fprofile-arcs;-ftest-coverage>"
 
     # release flags
     "$<$<CONFIG:RELEASE>:-O3;-DNDEBUG;-fno-omit-frame-pointer>"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Build Status](https://github.com/KFTrack/KinKal/workflows/KinKal/badge.svg)](https://github.com/KFTrack/KinKal/actions)
 
+[![codecov](https://codecov.io/gh/ryuwd/KinKal/branch/main/graph/badge.svg)](https://codecov.io/gh/ryuwd/KinKal)
+
+
 # Kinematic Kalman filter track fit code package
 
   KinKal implements a kinematic Kalman filter track fit (future ref to CTD/pub).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://github.com/KFTrack/KinKal/workflows/KinKal/badge.svg)](https://github.com/KFTrack/KinKal/actions)
-
-[![codecov](https://codecov.io/gh/ryuwd/KinKal/branch/main/graph/badge.svg)](https://codecov.io/gh/ryuwd/KinKal)
+[![codecov](https://codecov.io/gh/KFTrack/KinKal/branch/main/graph/badge.svg)](https://codecov.io/gh/KFTrack/KinKal)
 
 
 # Kinematic Kalman filter track fit code package

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -69,7 +69,7 @@ foreach( testsourcefile ${TEST_SOURCE_FILES} )
 
     # register the target as a test 
     add_test (NAME ${testname} COMMAND Test_${testname} )
-    set_tests_properties(${testname} PROPERTIES TIMEOUT 600) 
+    set_tests_properties(${testname} PROPERTIES TIMEOUT 250) 
     set_tests_properties(${testname} PROPERTIES ENVIRONMENT "PACKAGE_SOURCE=${CMAKE_SOURCE_DIR}")
 
     install( TARGETS Test_${testname}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -69,7 +69,7 @@ foreach( testsourcefile ${TEST_SOURCE_FILES} )
 
     # register the target as a test 
     add_test (NAME ${testname} COMMAND Test_${testname} )
-    set_tests_properties(${testname} PROPERTIES TIMEOUT 200) 
+    set_tests_properties(${testname} PROPERTIES TIMEOUT 300) 
     set_tests_properties(${testname} PROPERTIES ENVIRONMENT "PACKAGE_SOURCE=${CMAKE_SOURCE_DIR}")
 
     install( TARGETS Test_${testname}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -69,7 +69,7 @@ foreach( testsourcefile ${TEST_SOURCE_FILES} )
 
     # register the target as a test 
     add_test (NAME ${testname} COMMAND Test_${testname} )
-    set_tests_properties(${testname} PROPERTIES TIMEOUT 300) 
+    set_tests_properties(${testname} PROPERTIES TIMEOUT 600) 
     set_tests_properties(${testname} PROPERTIES ENVIRONMENT "PACKAGE_SOURCE=${CMAKE_SOURCE_DIR}")
 
     install( TARGETS Test_${testname}


### PR DESCRIPTION
A nice code tool I've been looking into recently. Unit test coverage % is calculated using `gcov` / `llvm-coverage gcov` and coverage flags in gcc or clang (depending on platform). Test coverage tells you which lines of code are covered by unit test cases, and which are missed

CI job also reports test coverage by uploading `gcovr` (`pip install gcovr`) generated reports to codecov.io (needs signup at https://codecov.io/gh - free)

Example PR: https://github.com/ryuwd/KinKal/pull/44#issuecomment-831080534
Example codecov report: https://codecov.io/gh/ryuwd/KinKal/tree/85a742f909846908d9bad62739703416600456ea

`make coverage` prints the coverage report in the terminal (requires `-DCOVERAGE=ON` to be passed to `cmake` + a debug build)