### PR TITLE
Added commentary about radiative energy losses

### DIFF
--- a/MatEnv/DetMaterial.cc
+++ b/MatEnv/DetMaterial.cc
@@ -49,7 +49,7 @@ namespace MatEnv {
 
   double cm(10.0); // temporary hack
   DetMaterial::DetMaterial(const char* detMatName, const MtrPropObj* detMtrProp):
-    _elossmode(mpv), //Energy Loss model: choose 'mpv' for the Most Probable Energy Loss, or 'moyalmean' for the mean calculated via the Moyal Distribution approximation, see end of file for more information
+    _elossmode(mpv), //Energy Loss model: choose 'mpv' for the Most Probable Energy Loss, or 'moyalmean' for the mean calculated via the Moyal Distribution approximation, see end of file for more information, as well as discussion about radiative losses
     _msmom(15.0),
     _scatterfrac(0.9999),
     _cutOffEnergy(1000.),
@@ -522,6 +522,10 @@ namespace MatEnv {
 //The Moyal distribution is an approximation for the ionization energy loss distribution. Unlike the Landau distribution is provides a closed-form energy loss mean and RMS. Code above uses the closed-form Moyal RMS for RMS, and allows the option of choosing the closed-form Moyal mean for the total energy loss parameter, which utilizes the most probable energy loss function. The options for either most probable energy loss and moyal distribution mean is toggled with the DetMaterial class member '_elossmode' with the options 'mpv' or 'moyalmean' respectively.
 //reference for Moyal dist.: Theory of Ionization Fluctuation by J. E. Moyal, Phil. Mag. 46 (1955) 263
 //more useful references: https://reference.wolfram.com/language/ref/MoyalDistribution.html, http://www.stat.rice.edu/~dobelman/textfiles/DistributionsHandbook.pdf, and https://arxiv.org/pdf/1702.06655.pdf
-	
+
+//Information about Radiative Energy Losses:
+
+//Since radiative energy losses have a highly non-Gaussian distribution in thin materials such as the tracker, we do not correct for average radiative energy loss here. The most probable energy loss value is 0 with a long tail, and rare electrons with high radiative losses would be rejected by the filter anyways due to failed or poor fitting. We do not want to overcorrect most electrons with 0 radiative loss. 
+//Useful reference which expands on this (sections 2.2, 2.3): Matthews, J. L., D. J. S. Findlay, and R. O. Owens. "The distribution of electron energy losses in thin absorbers." Nuclear Instruments and Methods 180.2-3 (1981): 573-579.
 
 }


### PR DESCRIPTION
Added comments clarifying why we do not correct for radiative energy losses here -- most electrons have 0 radiative losses in thin materials