### PR TITLE
Modifications to DetMaterial

### DIFF
--- a/MatEnv/DetMaterial.cc
+++ b/MatEnv/DetMaterial.cc
@@ -147,19 +147,15 @@ namespace MatEnv {
         double Eexc2 = _eexc*_eexc ;
 
         // New energy loss implementation
-
-        //double Tmax,gamma2,beta2,bg2,rcut,delta,x,sh,dedx ;
         double Tmax,gamma2,beta2,bg2,rcut,delta,sh,dedx ;
         double beta  = particleBeta(mom,mass) ;
         double gamma = particleGamma(mom,mass) ;
         double tau = gamma-1. ;
 
         // high energy part , Bethe-Bloch formula
-
         beta2 = beta*beta ;
         gamma2 = gamma*gamma ;
         bg2 = beta2*gamma2 ;
-
 
         double RateMass = e_mass_/ mass;
 
@@ -198,22 +194,17 @@ namespace MatEnv {
         pathlen = fabs(pathlen) ;
 
         // New energy loss implementation
-
-        // double gamma2,beta2,bg2,delta,x, xi, deltap, sh ;
         double gamma2,beta2,bg2,delta, deltap, sh, xi;
         double beta  = particleBeta(mom,mass) ;
         double gamma = particleGamma(mom,mass) ;
         double j = 0.200 ;
-        //double thickness = _density*pathlen ;
         double tau = gamma-1;
 
 
         // most probable energy loss function
-
         beta2 = beta*beta ;
         gamma2 = gamma*gamma ;
         bg2 = beta2*gamma2 ;
-        //xi = _dgev*_za * thickness / beta2 ;
         xi = eloss_xi(beta, pathlen); 
 
         deltap = log(2.*e_mass_*bg2/_eexc) + log(xi/_eexc);
@@ -245,7 +236,7 @@ namespace MatEnv {
 
   //////////////////////////////////////////////////////////
 
-  // // Calculate moyal mean 
+  //// Calculate Moyal mean 
   double 
     DetMaterial::moyalMean(double deltap, double xi) const{
       //getting most probable energy loss, or mpv:
@@ -263,7 +254,7 @@ namespace MatEnv {
           return -1.0 * mmean;
     }
 
-  // //Calculate density correction for energy loss 
+  ////Calculate density correction for energy loss 
   double 
     DetMaterial::densityCorrection(double bg2) const {
       // density correction
@@ -284,8 +275,8 @@ namespace MatEnv {
         }
         return delta;
     }
-
-  // // Caluclate shell correction for energy loss 
+    
+  //// Caluclate shell correction for energy loss 
   double 
     DetMaterial::shellCorrection(double bg2, double tau) const {
        double sh = 0;

--- a/MatEnv/DetMaterial.hh
+++ b/MatEnv/DetMaterial.hh
@@ -109,7 +109,7 @@ namespace MatEnv {
       double eloss_xi(double beta,double pathlen) const;
       double densityCorrection(double bg2) const;
       double shellCorrection(double bg2, double tau) const;
-      double moyalMean(double deltap, double moyalsigma) const;
+      double moyalMean(double deltap, double xi) const;
       double kappa(double mom,double pathlen,double mass) const {
         return eloss_xi(particleBeta(mom,mass),pathlen)/eloss_emax(mom,mass);}
       //


### PR DESCRIPTION
- Calculation of xi is now through the eloss_xi in energyLoss(). 
- Calculation of the moyal mean parameter has been moved to separate function moyalMean(). The definition of moyalsigma is also updated in the  moyalMean() and energyLossRMS() to present the moyal parameters with better clarity. 
- The method of calculating shell correction and density correction was  repeated in dEdx() and energyLoss(). Created separate functions for calculating shellCorrection() and densityCorrection() making the code easier to read. 