### PR TITLE
Configuration and TimeRange fixes

### DIFF
--- a/Detector/ElementXing.hh
+++ b/Detector/ElementXing.hh
@@ -9,7 +9,7 @@
 #include "KinKal/Trajectory/ParticleTrajectory.hh"
 #include "KinKal/General/TimeDir.hh"
 #include "KinKal/Detector/Hit.hh"
-#include "KinKal/Fit/Config.hh"
+#include "KinKal/Fit/MetaIterConfig.hh"
 #include <vector>
 #include <stdexcept>
 #include <array>

--- a/Detector/Hit.hh
+++ b/Detector/Hit.hh
@@ -9,7 +9,7 @@
 #include "KinKal/General/Parameters.hh"
 #include "KinKal/General/Chisq.hh"
 #include "KinKal/Trajectory/ParticleTrajectory.hh"
-#include "KinKal/Fit/Config.hh"
+#include "KinKal/Fit/MetaIterConfig.hh"
 #include <ostream>
 
 namespace KinKal {

--- a/Fit/BFieldEffect.hh
+++ b/Fit/BFieldEffect.hh
@@ -23,6 +23,7 @@ namespace KinKal {
       bool active() const override { return bfcorr_; }
       void update(PKTRAJ const& ref) override;
       void update(PKTRAJ const& ref, MetaIterConfig const& miconfig) override;
+      void update(Config const& config) override { bfcorr_ = config.bfcorr_; }
       void print(std::ostream& ost=std::cout,int detail=0) const override;
       void process(FitState& kkdata,TimeDir tdir) override;
       void append(PKTRAJ& fit) override;

--- a/Fit/CMakeLists.txt
+++ b/Fit/CMakeLists.txt
@@ -5,8 +5,9 @@
 # Globbing is not recommended, see: https://cmake.org/cmake/help/v3.12/command/file.html#filesystem
 
 # you can regenerate this list easily by running in this directory: ls -1 *.cc
-add_library(Fit SHARED 
+add_library(Fit SHARED
     Config.cc
+    MetaIterConfig.cc
     Status.cc
 )
 

--- a/Fit/Config.cc
+++ b/Fit/Config.cc
@@ -1,7 +1,7 @@
 #include "KinKal/Fit/Config.hh"
 namespace KinKal {
   std::ostream& operator <<(std::ostream& ost, MetaIterConfig const& miconfig ) {
-      ost << "Meta-Iteration " << miconfig.miter_ << " temp " << miconfig.temp_;
+      ost << "Meta-Iteration temp " << miconfig.temp_;
       ost << " with " << miconfig.updaters_.size() << " Dedicated Updaters";
       return ost;
   }

--- a/Fit/Config.cc
+++ b/Fit/Config.cc
@@ -1,11 +1,5 @@
 #include "KinKal/Fit/Config.hh"
 namespace KinKal {
-  std::ostream& operator <<(std::ostream& ost, MetaIterConfig const& miconfig ) {
-      ost << "Meta-Iteration temp " << miconfig.temp_;
-      ost << " with " << miconfig.updaters_.size() << " Dedicated Updaters";
-      return ost;
-  }
-
   std::ostream& operator <<(std::ostream& ost, Config const& kkconfig ) {
     ost << "Config maxniter " << kkconfig.maxniter_
       << " dweight " << kkconfig.dwt_

--- a/Fit/Config.hh
+++ b/Fit/Config.hh
@@ -19,11 +19,10 @@
 namespace KinKal {
   struct MetaIterConfig {
     double temp_; // 'temperature' to use in the simulated annealing (dimensionless, roughly equivalent to 'sigma')
-    int miter_; // count of meta-iteration
     // payload for effects needing special updating; specific Effect subclasses can find their particular updater inside the vector
     std::vector<std::any> updaters_;
-    MetaIterConfig() : temp_(0.0),  miter_(-1) {}
-    MetaIterConfig(double temp,  int miter) : temp_(temp), miter_(miter) {}
+    MetaIterConfig() : temp_(0.0) {}
+    MetaIterConfig(double temp) : temp_(temp) {}
     double varianceScale() const { return (1.0+temp_)*(1.0+temp_); } // variance scale so that temp=0 means no additional variance
   };
 

--- a/Fit/Config.hh
+++ b/Fit/Config.hh
@@ -5,27 +5,16 @@
 //  the fit (BFieldMap maps, material model), the iteration schedule through which the fit should proceed,
 //  and the convergence criteria for that.
 //
-// struct to define a single meta-iteration of the KKTrk fit.  Each meta-iteration configuration is held
-// constant until the algebraic iteration implicit in the extended Kalman fit methodology converges.
 //
+#include "KinKal/General/Vectors.hh"
+#include "KinKal/Fit/MetaIterConfig.hh"
 #include <vector>
 #include <memory>
 #include <algorithm>
-#include <any>
 #include <ostream>
 #include <istream>
-#include "KinKal/General/Vectors.hh"
 
 namespace KinKal {
-  struct MetaIterConfig {
-    double temp_; // 'temperature' to use in the simulated annealing (dimensionless, roughly equivalent to 'sigma')
-    // payload for effects needing special updating; specific Effect subclasses can find their particular updater inside the vector
-    std::vector<std::any> updaters_;
-    MetaIterConfig() : temp_(0.0) {}
-    MetaIterConfig(double temp) : temp_(temp) {}
-    double varianceScale() const { return (1.0+temp_)*(1.0+temp_); } // variance scale so that temp=0 means no additional variance
-  };
-
   struct Config {
     enum printLevel{none=0,minimal, basic, complete, detailed, extreme};
     using Schedule =  std::vector<MetaIterConfig>;
@@ -49,6 +38,5 @@ namespace KinKal {
     Schedule schedule_;
   };
   std::ostream& operator <<(std::ostream& os, Config const& kkconfig );
-  std::ostream& operator <<(std::ostream& os, MetaIterConfig const& miconfig );
 }
 #endif

--- a/Fit/Effect.hh
+++ b/Fit/Effect.hh
@@ -31,6 +31,8 @@ namespace KinKal {
       virtual void update(PKTRAJ const& ref) = 0;
       // update this effect to start a new algebraic iteration squence using the new reference trajectory and configuration
       virtual void update(PKTRAJ const& ref, MetaIterConfig const& miconfig) = 0;
+      // update this effect for a new configuration
+      virtual void update(Config const& config) =0;
       // diagnostic printout
       virtual void print(std::ostream& ost=std::cout,int detail=0) const =0;
       // the following only has a non-trivial implementation for effects which (potentially) add information content to the fit

--- a/Fit/HitConstraint.hh
+++ b/Fit/HitConstraint.hh
@@ -22,6 +22,7 @@ namespace KinKal {
       Chisq chisq() const override;
       void update(PKTRAJ const& pktraj) override;
       void update(PKTRAJ const& pktraj, MetaIterConfig const& miconfig) override;
+      void update(Config const& config) override {}
       void process(FitState& kkdata,TimeDir tdir) override;
       bool active() const override { return hit_->active(); }
       double time() const override { return hit_->time(); }

--- a/Fit/Material.hh
+++ b/Fit/Material.hh
@@ -46,7 +46,7 @@ namespace KinKal {
       static double tbuff_; // small time buffer to avoid ambiguity
   };
 
-  template<class KTRAJ> double Material<KTRAJ>::tbuff_ = 1.0e-3;
+  template<class KTRAJ> double Material<KTRAJ>::tbuff_ = 1.0e-6; // small buffer to disambiguate this effect
 
   template<class KTRAJ> Material<KTRAJ>::Material(EXINGPTR const& dxing, PKTRAJ const& pktraj) : dxing_(dxing),
   ref_(pktraj.nearestPiece(dxing->crossingTime())), vscale_(1.0) {

--- a/Fit/Material.hh
+++ b/Fit/Material.hh
@@ -23,6 +23,7 @@ namespace KinKal {
       bool active() const override { return  dxing_->active(); }
       void update(PKTRAJ const& ref) override;
       void update(PKTRAJ const& ref, MetaIterConfig const& miconfig) override;
+      void update(Config const& config) override {}
       void print(std::ostream& ost=std::cout,int detail=0) const override;
       void process(FitState& kkdata,TimeDir tdir) override;
       void append(PKTRAJ& fit) override;

--- a/Fit/MetaIterConfig.cc
+++ b/Fit/MetaIterConfig.cc
@@ -1,0 +1,8 @@
+#include "KinKal/Fit/MetaIterConfig.hh"
+namespace KinKal {
+  std::ostream& operator <<(std::ostream& ost, MetaIterConfig const& miconfig ) {
+      ost << "Meta-Iteration temp " << miconfig.temp_;
+      ost << " with " << miconfig.updaters_.size() << " Dedicated Updaters";
+      return ost;
+  }
+}

--- a/Fit/MetaIterConfig.hh
+++ b/Fit/MetaIterConfig.hh
@@ -1,0 +1,21 @@
+#ifndef KinKal_MetaIterConfig_hh
+#define KinKal_MetaIterConfig_hh
+//
+// struct to define a single meta-iteration of the KKTrk fit.  Each meta-iteration configuration is held
+// constant until the algebraic iteration implicit in the extended Kalman fit methodology converges.
+//
+#include <vector>
+#include <any>
+#include <ostream>
+namespace KinKal {
+  struct MetaIterConfig {
+    double temp_; // 'temperature' to use in the simulated annealing (dimensionless, roughly equivalent to 'sigma')
+    // payload for effects needing special updating; specific Effect subclasses can find their particular updater inside the vector
+    std::vector<std::any> updaters_;
+    MetaIterConfig() : temp_(0.0) {}
+    MetaIterConfig(double temp) : temp_(temp) {}
+    double varianceScale() const { return (1.0+temp_)*(1.0+temp_); } // variance scale so that temp=0 means no additional variance
+  };
+  std::ostream& operator <<(std::ostream& os, MetaIterConfig const& miconfig );
+}
+#endif

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -169,7 +169,7 @@ namespace KinKal {
     if(!fitStatus().usable())throw std::invalid_argument("Cannot extend unusable fit");
     // find the range of the added information, and extend as needed
     TimeRange exrange = getRange(hits,exings);
-    if(!exrange.infinite()){
+    if(!exrange.null()){
       exrange.begin() = std::min(exrange.begin(),reftraj_.range().begin());
       exrange.end() = std::max(exrange.end(),reftraj_.range().end());
     } else {

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -162,7 +162,6 @@ namespace KinKal {
   // extend an existing track
   template <class KTRAJ> void Track<KTRAJ>::extend(Config const& cfg, HITCOL& hits, EXINGCOL& exings) {
     // update the configuration
-    auto const& oldconfig(config());
     config_.push_back(cfg);
     // configuation check
     if(config().schedule().size() ==0)throw std::invalid_argument("Invalid configuration: no schedule");
@@ -179,7 +178,8 @@ namespace KinKal {
     DOMAINCOL domains;
     if(config().bfcorr_ ) {
       // if the previous configuration didn't have domains, then create them for the full reference range
-      if(!oldconfig.bfcorr_){
+      auto oldconfig = config_.end();  --oldconfig; --oldconfig;
+      if(!oldconfig->bfcorr_){
         // create domains for the whole range
         createDomains(reftraj_, exrange,domains);
         // replace the reftraj with one with BField rotations
@@ -204,6 +204,8 @@ namespace KinKal {
     }
     // create the effects for the new info and the new domains
     createEffects(hits,exings,domains);
+    // update all the effects for this new configuration
+    for(auto& ieff : effects_ ) ieff->update(config());
     // now refit the track
     fit();
   }

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -170,8 +170,7 @@ namespace KinKal {
     // find the range of the added information, and extend as needed
     TimeRange exrange = getRange(hits,exings);
     if(!exrange.null()){
-      exrange.begin() = std::min(exrange.begin(),reftraj_.range().begin());
-      exrange.end() = std::max(exrange.end(),reftraj_.range().end());
+      exrange = TimeRange(std::min(exrange.begin(),reftraj_.range().begin()), std::max(exrange.end(),reftraj_.range().end()));
     } else {
       exrange = reftraj_.range();
     }
@@ -365,8 +364,8 @@ namespace KinKal {
     // trim the range to the physical elements (past the end sites)
     feff = effects_.begin(); feff++;
     beff = effects_.rbegin(); beff++;
-    fittraj_.front().range().begin() = (*feff)->time() - config().tbuff_;
-    fittraj_.back().range().end() = (*beff)->time() + config().tbuff_;
+    fittraj_.front().range() = TimeRange((*feff)->time() - config().tbuff_,fittraj_.front().range().end());
+    fittraj_.back().range() = TimeRange(fittraj_.back().range().begin(),(*beff)->time() + config().tbuff_);
     // compute parameter difference WRT reference.  Compare in the middle
     auto const& mtraj = fittraj_.nearestPiece(fittraj_.range().mid());
     auto const& rtraj = reftraj_.nearestPiece(fittraj_.range().mid());

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -168,11 +168,10 @@ namespace KinKal {
     // require the existing fit to be usable
     if(!fitStatus().usable())throw std::invalid_argument("Cannot extend unusable fit");
     // find the range of the added information, and extend as needed
-    TimeRange exrange = getRange(hits,exings);
-    if(!exrange.null()){
-      exrange = TimeRange(std::min(exrange.begin(),reftraj_.range().begin()), std::max(exrange.end(),reftraj_.range().end()));
-    } else {
-      exrange = reftraj_.range();
+    TimeRange exrange = reftraj_.range();
+    if(hits.size() >0 | exings.size() > 0){
+      TimeRange newrange = getRange(hits,exings);
+      exrange.combine(newrange);
     }
     DOMAINCOL domains;
     if(config().bfcorr_ ) {

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -169,7 +169,7 @@ namespace KinKal {
     if(!fitStatus().usable())throw std::invalid_argument("Cannot extend unusable fit");
     // find the range of the added information, and extend as needed
     TimeRange exrange = reftraj_.range();
-    if(hits.size() >0 | exings.size() > 0){
+    if(hits.size() >0 || exings.size() > 0){
       TimeRange newrange = getRange(hits,exings);
       exrange.combine(newrange);
     }
@@ -362,9 +362,11 @@ namespace KinKal {
     }
     // trim the range to the physical elements (past the end sites)
     feff = effects_.begin(); feff++;
+    double fefftime = (*feff)->time() - config().tbuff_;
     beff = effects_.rbegin(); beff++;
-    fittraj_.front().range() = TimeRange((*feff)->time() - config().tbuff_,fittraj_.front().range().end());
-    fittraj_.back().range() = TimeRange(fittraj_.back().range().begin(),(*beff)->time() + config().tbuff_);
+    double befftime = (*beff)->time() + config().tbuff_;
+    fittraj_.front().range().combine(TimeRange(fefftime,fefftime));
+    fittraj_.back().range().combine(TimeRange(befftime,befftime));
     // compute parameter difference WRT reference.  Compare in the middle
     auto const& mtraj = fittraj_.nearestPiece(fittraj_.range().mid());
     auto const& rtraj = reftraj_.nearestPiece(fittraj_.range().mid());

--- a/General/BFieldMap.hh
+++ b/General/BFieldMap.hh
@@ -66,7 +66,7 @@ namespace KinKal {
     if(d2pdt2 > 1e-10)
       return tstart + sqrt(dp/d2pdt2);
     else
-      return ktraj.range().end()+0.001; // add a small buffer to avoid logical problems
+      return ktraj.range().end();
   }
 
   // trivial instance of the above, used for testing

--- a/General/TimeRange.cc
+++ b/General/TimeRange.cc
@@ -1,10 +1,7 @@
 #include "KinKal/General/TimeRange.hh"
 namespace KinKal {
   std::ostream& operator <<(std::ostream& ost, TimeRange const& trange) {
-    if(trange.infinite())
-      ost << " Infinite Range ";
-    else
-      ost << " Range [" << trange.begin() << "," << trange.end() << "]";
+    ost << " Range [" << trange.begin() << "," << trange.end() << "]";
     return ost;
   }
 }

--- a/General/TimeRange.hh
+++ b/General/TimeRange.hh
@@ -1,6 +1,6 @@
 #ifndef KinKal_TimeRange_hh
 #define KinKal_TimeRange_hh
-// simple struct to describe a time range, defined [ )
+// simple struct to describe a monotonic time range, defined [).
 #include <algorithm>
 #include <ostream>
 #include <array>
@@ -8,10 +8,9 @@
 namespace KinKal {
   class TimeRange {
     public:
-      TimeRange() : range_{0.0,0.0} {} // initialize to have null
+      TimeRange() : range_{0.0,0.0} {} // default to a null range (matches no times)
       TimeRange(double begin, double end) : range_{begin,end} {
-        if(begin > end)throw std::invalid_argument("Invalid Range");
-      }
+        if(begin > end)throw std::invalid_argument("Invalid Range"); }
       double begin() const { return range_[0]; }
       double end() const { return range_[1]; }
       double mid() const { return 0.5*(begin()+end()); }
@@ -24,7 +23,7 @@ namespace KinKal {
         return (begin() <= other.begin() && end() >= other.end()); }
       // force time to be in range
       void forceRange(double& time) const { time = std::min(std::max(time,begin()),end()); }
-      // augment using another range
+      // augment another range
       void combine(TimeRange const& other ) {
         range_[0] = std::min(begin(),other.begin());
         range_[1] = std::max(end(),other.end());

--- a/General/TimeRange.hh
+++ b/General/TimeRange.hh
@@ -14,8 +14,8 @@ namespace KinKal {
       double end() const { return range_[1]; }
       double mid() const { return 0.5*(range_[0]+range_[1]); }
       double range() const { return (range_[1]-range_[0]); }
-      double& begin() { return range_[0]; }
-      double& end() { return range_[1]; }
+//      double& begin() { return range_[0]; }
+//      double& end() { return range_[1]; }
       bool null() const { return end() == begin(); }
       bool overlaps(TimeRange const& other ) const {
         return (end() > other.begin() || begin() < other.end()); }

--- a/General/TimeRange.hh
+++ b/General/TimeRange.hh
@@ -12,16 +12,16 @@ namespace KinKal {
       TimeRange(double begin, double end) : range_{begin,end} {
         if(begin > end)throw std::invalid_argument("Invalid Range");
       }
-      bool inRange(double t) const {return t >= range_[0] && t < range_[1]; }
       double begin() const { return range_[0]; }
       double end() const { return range_[1]; }
-      double mid() const { return 0.5*(range_[0]+range_[1]); }
-      double range() const { return (range_[1]-range_[0]); }
+      double mid() const { return 0.5*(begin()+end()); }
+      double range() const { return (end()-begin()); }
+      bool inRange(double t) const {return t >= begin() && t < end(); }
       bool null() const { return end() == begin(); }
       bool overlaps(TimeRange const& other ) const {
         return (end() > other.begin() || begin() < other.end()); }
       bool contains(TimeRange const& other) const {
-        return (begin() < other.begin() && end() > other.end()); }
+        return (begin() <= other.begin() && end() >= other.end()); }
       // force time to be in range
       void forceRange(double& time) const { time = std::min(std::max(time,begin()),end()); }
       // augment using another range

--- a/General/TimeRange.hh
+++ b/General/TimeRange.hh
@@ -4,18 +4,19 @@
 #include <algorithm>
 #include <ostream>
 #include <array>
+#include <stdexcept>
 namespace KinKal {
   class TimeRange {
     public:
       TimeRange() : range_{0.0,0.0} {} // initialize to have null
-      TimeRange(double begin, double end) : range_{begin,end} {}
+      TimeRange(double begin, double end) : range_{begin,end} {
+        if(begin > end)throw std::invalid_argument("Invalid Range");
+      }
       bool inRange(double t) const {return t >= range_[0] && t < range_[1]; }
       double begin() const { return range_[0]; }
       double end() const { return range_[1]; }
       double mid() const { return 0.5*(range_[0]+range_[1]); }
       double range() const { return (range_[1]-range_[0]); }
-//      double& begin() { return range_[0]; }
-//      double& end() { return range_[1]; }
       bool null() const { return end() == begin(); }
       bool overlaps(TimeRange const& other ) const {
         return (end() > other.begin() || begin() < other.end()); }

--- a/General/TimeRange.hh
+++ b/General/TimeRange.hh
@@ -7,17 +7,16 @@
 namespace KinKal {
   class TimeRange {
     public:
-      static constexpr double tbuff_ = 1.0e-10; // small buffer to prevent overlaps between adjacent trajs
-      TimeRange() : range_{1.0,-1.0} {} // initialize to have infinite range
+      TimeRange() : range_{0.0,0.0} {} // initialize to have null
       TimeRange(double begin, double end) : range_{begin,end} {}
-      bool inRange(double t) const { return infinite() || (t >= range_[0] && t < range_[1]); }
+      bool inRange(double t) const {return t >= range_[0] && t < range_[1]; }
       double begin() const { return range_[0]; }
       double end() const { return range_[1]; }
       double mid() const { return 0.5*(range_[0]+range_[1]); }
       double range() const { return (range_[1]-range_[0]); }
       double& begin() { return range_[0]; }
       double& end() { return range_[1]; }
-      bool infinite() const { return end() + tbuff_ < begin(); }
+      bool null() const { return end() == begin(); }
       bool overlaps(TimeRange const& other ) const {
         return (end() > other.begin() || begin() < other.end()); }
       bool contains(TimeRange const& other) const {

--- a/General/TimeRange.hh
+++ b/General/TimeRange.hh
@@ -23,8 +23,11 @@ namespace KinKal {
         return (begin() < other.begin() && end() > other.end()); }
       // force time to be in range
       void forceRange(double& time) const { time = std::min(std::max(time,begin()),end()); }
-      // test if a time is at the limit
-      bool atLimit(double time) const { return time >= end() || time <= begin(); }
+      // augment using another range
+      void combine(TimeRange const& other ) {
+        range_[0] = std::min(begin(),other.begin());
+        range_[1] = std::max(end(),other.end());
+      }
     private:
       std::array<double,2> range_; // range of times
   };

--- a/Tests/BFieldMapTest.hh
+++ b/Tests/BFieldMapTest.hh
@@ -116,7 +116,7 @@ int BFieldMapTest(int argc, char **argv) {
   TimeRange prange = start.range();
   do {
     auto const& piece = xptraj.back();
-    prange.end() = BF->rangeInTolerance(piece,prange.begin(), tol);
+    prange = TimeRange(prange.begin(),BF->rangeInTolerance(piece,prange.begin(), tol));
     // integrate the momentum change over this range
     VEC3 dp = BF->integrate(piece,prange);
     // approximate change in position

--- a/Tests/FitTest.hh
+++ b/Tests/FitTest.hh
@@ -124,7 +124,7 @@ int makeConfig(string const& cfile, KinKal::Config& config) {
       } else {
         double temp, mindoca(-1.0),maxdoca(-1.0), minprob(-1.0);
         ss >> temp >> mindoca >> maxdoca >> minprob;
-        MetaIterConfig mconfig(temp, nmiter++);
+        MetaIterConfig mconfig(temp);
         if(mindoca >0.0 || maxdoca > 0.0){
           // setup and insert the updater
           cout << "SimpleWireHitUpdater for iteration " << nmiter << " with mindoca " << mindoca << " maxdoca " << maxdoca << " minprob " << minprob << endl;

--- a/Tests/ToyMC.hh
+++ b/Tests/ToyMC.hh
@@ -238,21 +238,17 @@ namespace KKTest {
     dBdt = bfield_.fieldDeriv(pos,vel);
     //    std::cout << "end time " << pktraj.back().range().begin() << " hit time " << htime << std::endl;
     if(dBdt.R() != 0.0){
-      TimeRange prange(pktraj.back().range().begin(),pktraj.back().range().begin());
-      prange.end() = bfield_.rangeInTolerance(pktraj.back(),prange.begin(),tol_);
-      if(prange.end() > htime) {
-        return;
-      } else {
-        prange.begin() = prange.end();
-        do {
-          prange.end() = bfield_.rangeInTolerance(pktraj.back(),prange.begin(),tol_);
-          VEC4 pos = pktraj.position4(prange.begin());
-          MOM4 mom =  pktraj.momentum4(prange.begin());
-          VEC3 bf = bfield_.fieldVect(pktraj.position3(prange.mid()));
-          KTRAJ newend(pos,mom,pktraj.charge(),bf,prange);
-          pktraj.append(newend);
-          prange.begin() = prange.end();
-        } while(prange.end() < htime);
+      double tbeg = bfield_.rangeInTolerance(pktraj.back(),pktraj.back().range().begin(),tol_);
+      double tend = pktraj.back().range().end();
+      while(tbeg < htime) {
+        auto pos = pktraj.position4(tbeg);
+        auto mom =  pktraj.momentum4(tbeg);
+        double tnew = bfield_.rangeInTolerance(pktraj.back(),tbeg,tol_);
+        VEC3 bf = bfield_.fieldVect(pktraj.position3(0.5*(tbeg+tnew)));
+        TimeRange prange(tbeg,tend);
+        KTRAJ newend(pos,mom,pktraj.charge(),bf,prange);
+        pktraj.append(newend);
+        tbeg = tnew;
       }
     }
   }

--- a/Tests/ToyMC.hh
+++ b/Tests/ToyMC.hh
@@ -44,7 +44,7 @@ namespace KKTest {
         sprop_(0.8*CLHEP::c_light), sdrift_(0.065),
         zrange_(zrange), rstraw_(2.5), rwire_(0.025), wthick_(0.015), wlen_(1000.0), sigt_(3.0), ineff_(0.05),
         scitsig_(0.1), shPosSig_(10.0), shmax_(80.0), coff_(50.0), clen_(200.0), cprop_(0.8*CLHEP::c_light),
-        osig_(10.0), ctmin_(0.5), ctmax_(0.8), tbuff_(0.01), tol_(1e-5), tprec_(1e-8), t0off_(700.0),
+        osig_(10.0), ctmin_(0.5), ctmax_(0.8), tol_(1e-5), tprec_(1e-8), t0off_(700.0),
         smat_(matdb_,rstraw_, wthick_,rwire_) {}
 
       // generate a straw at the given time.  direction and drift distance are random
@@ -86,7 +86,6 @@ namespace KKTest {
       // time hit parameters
       double scitsig_, shPosSig_, shmax_, coff_, clen_, cprop_;
       double osig_, ctmin_, ctmax_;
-      double tbuff_;
       double tol_; // tolerance on momentum accuracy due to BField effects
       double tprec_; // time precision on TCA
       double t0off_; // t0 offset
@@ -122,11 +121,11 @@ namespace KKTest {
     createTraj(pktraj);
     // divide time range
     double dt(0.0);
-    if(nhits_ > 0) dt = (pktraj.range().range()-2*tbuff_)/(nhits_);
+    if(nhits_ > 0) dt = (pktraj.range().range())/(nhits_);
     VEC3 bsim;
     // create the hits (and associated materials)
     for(size_t ihit=0; ihit<nhits_; ihit++){
-      double htime = tbuff_ + pktraj.range().begin() + ihit*dt;
+      double htime = pktraj.range().begin() + ihit*dt;
       // extend the trajectory in the BFieldMap to this time
       extendTraj(pktraj,htime);
       // create the hit at this time
@@ -262,7 +261,7 @@ namespace KKTest {
     double tmax = fabs(zrange_/(CLHEP::c_light*tcost));
     VEC4 torigin(tr_.Gaus(0.0,osig_), tr_.Gaus(0.0,osig_), tr_.Gaus(-0.5*zrange_,osig_),tr_.Uniform(t0off_-tmax,t0off_+tmax));
     VEC3 bsim = bfield_.fieldVect(torigin.Vect());
-    KTRAJ ktraj(torigin,tmomv,icharge_,bsim,TimeRange(torigin.T(),torigin.T()+tmax+tbuff_));
+    KTRAJ ktraj(torigin,tmomv,icharge_,bsim,TimeRange(torigin.T(),torigin.T()+tmax));
     pktraj = PKTRAJ(ktraj);
   }
 }

--- a/Trajectory/PiecewiseTrajectory.hh
+++ b/Trajectory/PiecewiseTrajectory.hh
@@ -84,8 +84,8 @@ namespace KinKal {
   }
 
   template <class TTRAJ> void PiecewiseTrajectory<TTRAJ>::prepend(TTRAJ const& newpiece, bool allowremove) {
-    // new piece can't have infinite range
-    if(newpiece.range().infinite())throw std::invalid_argument("Can't prepend infinite range traj");
+    // new piece can't have null range
+    if(newpiece.range().null())throw std::invalid_argument("Can't prepend null range traj");
     if(pieces_.empty()){
       pieces_.push_back(newpiece);
     } else {
@@ -108,7 +108,7 @@ namespace KinKal {
         if(ipiece == 0){
           // update ranges and add the piece
           double tmin = std::min(newpiece.range().begin(),pieces_.front().range().begin());
-          pieces_.front().range().begin() = newpiece.range().end() +TimeRange::tbuff_;
+          pieces_.front().range().begin() = newpiece.range().end();
           pieces_.push_front(newpiece);
           pieces_.front().range().begin() = tmin;
         } else {
@@ -119,8 +119,8 @@ namespace KinKal {
   }
 
   template <class TTRAJ> void PiecewiseTrajectory<TTRAJ>::append(TTRAJ const& newpiece, bool allowremove) {
-    // new piece can't have infinite range
-    if(newpiece.range().infinite())throw std::invalid_argument("Can't append infinite range traj");
+    // new piece can't have null range
+    if(newpiece.range().null())throw std::invalid_argument("Can't append null range traj");
     if(pieces_.empty()){
       pieces_.push_back(newpiece);
     } else {
@@ -145,7 +145,7 @@ namespace KinKal {
           // first, make sure we don't loose range
           double tmax = std::max(newpiece.range().end(),pieces_.back().range().end());
           // truncate the range of the current back to match with the start of the new piece.  Leave a buffer on the upper range to prevent overlap
-          pieces_.back().range().end() = newpiece.range().begin()-TimeRange::tbuff_;
+          pieces_.back().range().end() = newpiece.range().begin();
           pieces_.push_back(newpiece);
           pieces_.back().range().end() = tmax;
         } else {

--- a/Trajectory/PiecewiseTrajectory.hh
+++ b/Trajectory/PiecewiseTrajectory.hh
@@ -144,7 +144,7 @@ namespace KinKal {
           // update ranges and add the piece.
           // first, make sure we don't loose range
           double tmax = std::max(newpiece.range().end(),pieces_.back().range().end());
-          // truncate the range of the current back to match with the start of the new piece.  Leave a buffer on the upper range to prevent overlap
+          // truncate the range of the current back to match with the start of the new piece.
           pieces_.back().range() = TimeRange(pieces_.back().range().begin(),newpiece.range().begin());
           pieces_.push_back(newpiece);
           pieces_.back().range() = TimeRange(pieces_.back().range().begin(),tmax);

--- a/Trajectory/PiecewiseTrajectory.hh
+++ b/Trajectory/PiecewiseTrajectory.hh
@@ -108,9 +108,9 @@ namespace KinKal {
         if(ipiece == 0){
           // update ranges and add the piece
           double tmin = std::min(newpiece.range().begin(),pieces_.front().range().begin());
-          pieces_.front().range().begin() = newpiece.range().end();
+          pieces_.front().range() = TimeRange(newpiece.range().end(),pieces_.front().range().end());
           pieces_.push_front(newpiece);
-          pieces_.front().range().begin() = tmin;
+          pieces_.front().range() = TimeRange(tmin,pieces_.front().range().end());
         } else {
           throw std::invalid_argument("range error");
         }
@@ -145,9 +145,9 @@ namespace KinKal {
           // first, make sure we don't loose range
           double tmax = std::max(newpiece.range().end(),pieces_.back().range().end());
           // truncate the range of the current back to match with the start of the new piece.  Leave a buffer on the upper range to prevent overlap
-          pieces_.back().range().end() = newpiece.range().begin();
+          pieces_.back().range() = TimeRange(pieces_.back().range().begin(),newpiece.range().begin());
           pieces_.push_back(newpiece);
-          pieces_.back().range().end() = tmax;
+          pieces_.back().range() = TimeRange(pieces_.back().range().begin(),tmax);
         } else {
           throw std::invalid_argument("range error");
         }


### PR DESCRIPTION
Fix bug with stale configuration cache when extending.  Enforce strict time ordering in TimeRange.  Eliminate 'time buffers' where possible.