### PR TITLE
Adding in sampling method for Bremsstrahlung energy loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/*
 KinKal/UnitTests/Dict.cc
 debug/*
 *.root
+.DS_Store
+.vscode

--- a/MatEnv/CMakeLists.txt
+++ b/MatEnv/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(MatEnv SHARED
     MtrPropObj.cc
     RecoMatFactory.cc
     SimpleFileFinder.cc
-    MoyalDist.cc
+    ELossDistributions.cc
 )
 
 # set top-level directory as include root

--- a/MatEnv/ELossDistributions.cc
+++ b/MatEnv/ELossDistributions.cc
@@ -93,7 +93,7 @@ namespace KinKal {
     do
     {
       Y =  dis(gen);
-    } while (Y < std::numeric_limits<double>::epsilon());
+    } while (Y < std::numeric_limits<double>::epsilon()); //condition to ignore zeros
 
      double bremssFraction = std::exp(-Y); // [(E0 - hn)/E0]
      double bremssLoss = energy * (1. - bremssFraction);
@@ -105,6 +105,7 @@ namespace KinKal {
   double BremssLoss::sampleSSPGamma(double energy, double radthickness) const{
     // This uses a method from https://arxiv.org/pdf/1302.1884.pdf
     // which is supposed to work better for small shape parameters 
+    // Performs only slightly better than std::gamma_distribution 
     double alpha = radthickness/M_LN2;
     double lambda = -1. + 1./alpha;
     double omega = alpha/(exp(1.)*(1.-alpha));
@@ -136,7 +137,7 @@ namespace KinKal {
             }
 
             Y = exp(-z/alpha);
-        } while (h_alpha/eta_alpha < dis(gen) || (Y < std::numeric_limits<double>::epsilon()) );
+        } while (h_alpha/eta_alpha < dis(gen) || (Y < std::numeric_limits<double>::epsilon()) ); //condition to ignore zeros
         
         
         double bremssFraction = std::exp(-Y); // [(E0 - hn)/E0]

--- a/MatEnv/ELossDistributions.cc
+++ b/MatEnv/ELossDistributions.cc
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <stdexcept>
 #include <cmath>
-#include "KinKal/MatEnv/MoyalDist.hh"
+#include "KinKal/MatEnv/ELossDistributions.hh"
 
 namespace KinKal {
   void MoyalDist::setCoeffs(int kmax){

--- a/MatEnv/ELossDistributions.cc
+++ b/MatEnv/ELossDistributions.cc
@@ -81,4 +81,69 @@ namespace KinKal {
     double x = _mode + _sigma * z;
     return (x) ;
   }
+
+  double BremssLoss::sampleSTDGamma(double energy, double radthickness) const{
+    // We can use the std::gamma_distribution; However it is computaionally inefficient 
+    // for very small shape parameter and generates a lot of zeros. 
+    std::random_device rd;  // Will be used to obtain a seed for the random number engine
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+    std::gamma_distribution<> dis(radthickness/M_LN2, 1.0);
+    double Y = 0; 
+    
+    do
+    {
+      Y =  dis(gen);
+    } while (Y < std::numeric_limits<double>::epsilon());
+
+     double bremssFraction = std::exp(-Y); // [(E0 - hn)/E0]
+     double bremssLoss = energy * (1. - bremssFraction);
+
+    return bremssLoss;
+
+  }
+
+  double BremssLoss::sampleSSPGamma(double energy, double radthickness) const{
+    // This uses a method from https://arxiv.org/pdf/1302.1884.pdf
+    // which is supposed to work better for small shape parameters 
+    double alpha = radthickness/M_LN2;
+    double lambda = -1. + 1./alpha;
+    double omega = alpha/(exp(1.)*(1.-alpha));
+    double rate = 1./(1. + omega);
+    double z =0;
+    double Y =0;
+    double eta_alpha = 0;
+    double h_alpha = 0;
+    
+    std::random_device rd;  // Will be used to obtain a seed for the random number engine
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+
+    do
+        {
+           double U = dis(gen);
+            if (U <= rate)
+            {
+                z = - log(U/rate);
+            } else {
+                z = log(dis(gen))/lambda;
+            }
+
+            h_alpha = exp( -z - exp(-z/alpha));
+            if(z>=0){
+                eta_alpha = exp(-z);
+            } else{
+                eta_alpha = omega * lambda * exp(lambda *z);
+            }
+
+            Y = exp(-z/alpha);
+        } while (h_alpha/eta_alpha < dis(gen) || (Y < std::numeric_limits<double>::epsilon()) );
+        
+        
+        double bremssFraction = std::exp(-Y); // [(E0 - hn)/E0]
+        double bremssLoss = energy * (1. - bremssFraction);
+
+        return bremssLoss;
+
+  }
+
 }

--- a/MatEnv/ELossDistributions.hh
+++ b/MatEnv/ELossDistributions.hh
@@ -1,5 +1,5 @@
-#ifndef KinKal_MatEnv_MoyalDist_HH
-#define KinKal_MatEnv_MoyalDist_HH
+#ifndef KinKal_MatEnv_ELossDistributions_HH
+#define KinKal_MatEnv_ELossDistributions_HH
 
 #include <iostream>
 #include <vector>

--- a/MatEnv/ELossDistributions.hh
+++ b/MatEnv/ELossDistributions.hh
@@ -47,5 +47,16 @@ namespace KinKal {
       static constexpr double EG = 0.577215664901532860606;    //Euler-gamma constant; replace this with numerics when we move to c++20
       static constexpr double MFACTOR = EG + M_LN2;
   };
+
+  /// Putting in a class for Bremsstrahlung loss
+  class BremssLoss
+  {
+  
+    public:
+      double sampleSTDGamma(double energy, double radthickenss) const; //standard c++ library for gamma distribution
+      double sampleSSPGamma(double energy, double radthickenss) const; //implementation of gamma distribution for small shape parameter
+  };
+  
+  
 }
 #endif

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set( TEST_SOURCE_FILES
     LoopHelix_unit.cc
     MatEnv_unit.cc
     MoyalDist_unit.cc
+    ELossDists_unit.cc
 )
 
 # Generate unit test targets

--- a/Tests/ELossDists_unit.cc
+++ b/Tests/ELossDists_unit.cc
@@ -97,24 +97,6 @@ int main(int argc, char **argv) {
   TH1F* elossTotal = new TH1F("elossTotal", "Total Loss", 500,  0., 100e-3);
   
   double nSamples = 100000;
-  
-  //Check which method generates faster 
-  auto start1 = std::chrono::high_resolution_clock::now(); //start time
-  for (int i = 0; i < nSamples; i++){
-    bLoss.sampleSTDGamma(momentum,radFrac);
-  }
-  auto finish1 = std::chrono::high_resolution_clock::now(); //end time
-  std::chrono::duration<double> elapsed1 = finish1 - start1;
-  std::cout << std::setw(50) << std::left << "Elapsed time for STDGamma method:" << elapsed1.count() << " s\n";
-
-  auto start2 = std::chrono::high_resolution_clock::now(); //start time
-  for (int i = 0; i < nSamples; i++){
-    bLoss.sampleSSPGamma(momentum,radFrac);
-  }
-  auto finish2 = std::chrono::high_resolution_clock::now(); //end time
-  std::chrono::duration<double> elapsed2 = finish2 - start2;
-  std::cout << std::setw(50) << std::left << "Elapsed time for SSPGamma method:" << elapsed2.count() << " s\n";
-
 
   for (int i = 0; i < nSamples; i++){
 
@@ -153,6 +135,22 @@ int main(int argc, char **argv) {
   gPad->BuildLegend();
   canvas->Write();
 
+  // Uncheck the lines below to compare performance of two BremssLoss methods
+  // //Check which method generates faster 
+  // auto start1 = std::chrono::high_resolution_clock::now(); //start time
+  // for (int i = 0; i < nSamples; i++){
+  //   bLoss.sampleSTDGamma(momentum,radFrac);
+  // }
+  // auto finish1 = std::chrono::high_resolution_clock::now(); //end time
+  // std::chrono::duration<double> elapsed1 = finish1 - start1;
+  // std::cout << std::setw(50) << std::left << "Elapsed time for STDGamma method:" << elapsed1.count() << " s\n";
 
+  // auto start2 = std::chrono::high_resolution_clock::now(); //start time
+  // for (int i = 0; i < nSamples; i++){
+  //   bLoss.sampleSSPGamma(momentum,radFrac);
+  // }
+  // auto finish2 = std::chrono::high_resolution_clock::now(); //end time
+  // std::chrono::duration<double> elapsed2 = finish2 - start2;
+  // std::cout << std::setw(50) << std::left << "Elapsed time for SSPGamma method:" << elapsed2.count() << " s\n";
 
 }

--- a/Tests/ELossDists_unit.cc
+++ b/Tests/ELossDists_unit.cc
@@ -1,0 +1,137 @@
+//
+// test basic functions of MatEnv and materials
+//
+#include "KinKal/MatEnv/MatDBInfo.hh"
+#include "KinKal/MatEnv/DetMaterial.hh"
+#include "KinKal/MatEnv/SimpleFileFinder.hh"
+
+#include <iostream>
+#include <stdio.h>
+#include <iostream>
+#include <getopt.h>
+
+#include "TH1F.h"
+#include "TSystem.h"
+#include "TFile.h"
+#include "TPad.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "KinKal/MatEnv/ELossDistributions.hh"
+
+using namespace std;
+using namespace MatEnv;
+using KinKal::MoyalDist;
+using KinKal::BremssLoss;
+
+void print_usage() {
+  printf("Usage: MatEnv --material c --particle i --momentum f  --thickness f\n");
+}
+
+int main(int argc, char **argv) {
+
+  string matname("straw-wall");
+  double momentum(100.0);
+  double thickness(0.015);
+  int imass(0);
+  double masses[5]={0.511,105.66,139.57, 493.68, 938.0};
+  const char* pnames[5] = {"electron","muon","pion","kaon","proton"};
+  double pmass;
+  string pname;
+
+  static struct option long_options[] = {
+    {"material",     required_argument, 0, 'c'  },
+    {"particle",     required_argument, 0, 'p'  },
+    {"momentum",     required_argument, 0, 's'  },
+    {"thickness",     required_argument, 0, 't'  },
+  };
+
+  int long_index =0;
+  int opt;
+
+  while ((opt = getopt_long_only(argc, argv,"", long_options, &long_index )) != -1) {
+    switch (opt) {
+      case 'c' :
+        matname = string(optarg);
+        break;
+      case 'p' :
+        imass =atoi(optarg);
+        break;
+      case 's' :
+        momentum = atof(optarg);
+        break;
+      case 't' :
+        thickness = atof(optarg);
+        break;
+      default: print_usage();
+               exit(EXIT_FAILURE);
+    }
+  }
+  pmass = masses[imass];
+  pname = pnames[imass];
+  cout << "Test for particle " << pname  << " mass " << pmass << endl;
+  cout << "Searching for material " << matname << endl;
+  MatEnv::SimpleFileFinder sfinder;
+  MatDBInfo matdbinfo(sfinder,MatEnv::DetMaterial::moyalmean);
+  const DetMaterial* dmat = matdbinfo.findDetMaterial(matname);
+  std::cout << "Found DetMaterial " << dmat->name() << std::endl;
+  
+  double eloss = dmat->energyLoss(momentum,thickness,pmass);
+  double elossrms = dmat->energyLossRMS(momentum,thickness,pmass);
+  MoyalDist mDist(MoyalDist::MeanRMS(abs(eloss), elossrms));
+  std::cout << "abs(eloss) = " << abs(eloss)  << std::endl;
+  std::cout << "elossrms = " << elossrms  << std::endl;
+  BremssLoss bLoss;
+
+  double radFrac = dmat->radiationFraction(thickness);
+  std::cout << "radiation fraction == " << radFrac << std::endl;
+
+  
+  std::unique_ptr<TFile> mFile( TFile::Open("ELossDists.root", "RECREATE") );
+  TH1F* histBrem = new TH1F("histBrem", "Bremss Loss", 500, 0, 100e-3);
+  TH1F* histCol = new TH1F("histCol", "Collision Loss", 500,  0., 100e-3);
+  TH1F* elossTotal = new TH1F("elossTotal", "Total Loss", 500,  0., 100e-3);
+  
+  double nSamples = 100000;
+  
+    
+  for (int i = 0; i < nSamples; i++){
+
+    // Here we assume that the particle loses energy first in collision and then in radiation
+    // Changing the order doesn't change the results. 
+    double colloss = mDist.sampleAR();
+    double bremloss = bLoss.sampleSSPGamma(momentum - colloss,radFrac); 
+
+    histBrem->Fill(bremloss);
+    histCol->Fill(colloss);
+    elossTotal->Fill(bremloss+colloss);
+  } 
+  
+  histBrem->SetLineColor(kRed);
+  histBrem->SetFillColor(kRed);
+  histBrem->SetFillStyle(3001);
+  histBrem->Write();
+
+  histCol->SetLineColor(kBlue);
+  histCol->SetFillColor(kBlue);
+  histCol->SetFillStyle(3001);
+  histCol->Write();
+
+  elossTotal->SetLineColor(kGreen);
+  elossTotal->SetFillColor(kGreen);
+  elossTotal->SetFillStyle(3001);
+  elossTotal->Write();
+
+  TCanvas* canvas = new TCanvas("canvas","canvas",1000,1000);
+  canvas->cd();
+  elossTotal->Draw();
+  
+  histCol->Draw("same");
+  histBrem->Draw("same");
+  gPad->SetLogy();
+  gPad->BuildLegend();
+  canvas->Write();
+
+
+
+}

--- a/Tests/ELossDists_unit.cc
+++ b/Tests/ELossDists_unit.cc
@@ -9,6 +9,10 @@
 #include <stdio.h>
 #include <iostream>
 #include <getopt.h>
+#include <iomanip>
+#include <random>
+#include <cmath>
+#include <chrono>
 
 #include "TH1F.h"
 #include "TSystem.h"
@@ -32,7 +36,7 @@ int main(int argc, char **argv) {
 
   string matname("straw-wall");
   double momentum(100.0);
-  double thickness(0.015);
+  double thickness(0.0015);
   int imass(0);
   double masses[5]={0.511,105.66,139.57, 493.68, 938.0};
   const char* pnames[5] = {"electron","muon","pion","kaon","proton"};
@@ -94,7 +98,24 @@ int main(int argc, char **argv) {
   
   double nSamples = 100000;
   
-    
+  //Check which method generates faster 
+  auto start1 = std::chrono::high_resolution_clock::now(); //start time
+  for (int i = 0; i < nSamples; i++){
+    bLoss.sampleSTDGamma(momentum,radFrac);
+  }
+  auto finish1 = std::chrono::high_resolution_clock::now(); //end time
+  std::chrono::duration<double> elapsed1 = finish1 - start1;
+  std::cout << std::setw(50) << std::left << "Elapsed time for STDGamma method:" << elapsed1.count() << " s\n";
+
+  auto start2 = std::chrono::high_resolution_clock::now(); //start time
+  for (int i = 0; i < nSamples; i++){
+    bLoss.sampleSSPGamma(momentum,radFrac);
+  }
+  auto finish2 = std::chrono::high_resolution_clock::now(); //end time
+  std::chrono::duration<double> elapsed2 = finish2 - start2;
+  std::cout << std::setw(50) << std::left << "Elapsed time for SSPGamma method:" << elapsed2.count() << " s\n";
+
+
   for (int i = 0; i < nSamples; i++){
 
     // Here we assume that the particle loses energy first in collision and then in radiation
@@ -106,7 +127,7 @@ int main(int argc, char **argv) {
     histCol->Fill(colloss);
     elossTotal->Fill(bremloss+colloss);
   } 
-  
+
   histBrem->SetLineColor(kRed);
   histBrem->SetFillColor(kRed);
   histBrem->SetFillStyle(3001);

--- a/Tests/MoyalDist_unit.cc
+++ b/Tests/MoyalDist_unit.cc
@@ -11,7 +11,7 @@
 #include "TF1.h"
 #include "TStyle.h"
 #include "TPad.h"
-#include "KinKal/MatEnv/MoyalDist.hh"
+#include "KinKal/MatEnv/ELossDistributions.hh"
 
 void print_usage() {
   printf("Usage: MatEnv --mean f --rms f --kmax i --nsamples d \n");


### PR DESCRIPTION
The methods have been added in a new file named ELossDistributions.cc(hh). This replaces the MoyalDist.cc(hh) file. The Moyal method was left untouched and only the Bremms class was added. It seemed reasonable to keep all distributions and random number sampling at a single place. 

A unit test was also added to plot both types of energy losses through a material of a certain thickness.  