### PR TITLE
Introduced CylBFieldMap interface.

### DIFF
--- a/General/CMakeLists.txt
+++ b/General/CMakeLists.txt
@@ -12,6 +12,9 @@ add_library(General SHARED
     Weights.cc
     BFieldMap.cc
     AxialBFieldMap.cc
+    InterpBilinear.cc
+    CylBMap.cc
+    CylBFieldMap.cc
     )
 
 # create shared library with ROOT dict

--- a/General/CylBFieldMap.cc
+++ b/General/CylBFieldMap.cc
@@ -1,0 +1,73 @@
+#include "KinKal/General/CylBFieldMap.hh"
+
+namespace KinKal{
+  using VEC = std::vector<double>;
+  using MAT = std::vector<std::vector<double>>;
+  
+  // CylBFieldMap::CylBFieldMap(std::string const& file)
+  //   : B_dat(file), Br_interp(B_dat.r(), B_dat.z(), B_dat.Br()),
+  //   Bz_interp(B_dat.r(), B_dat.z(), B_dat.Bz()) {}
+  CylBFieldMap::CylBFieldMap(std::string const& file)
+    : B_dat(file), Br_interp(B_dat.r_, B_dat.z_, B_dat.Br_),
+    Bz_interp(B_dat.r_, B_dat.z_, B_dat.Bz_) {}
+
+  VEC3 CylBFieldMap::fieldVect(VEC3 const& position) const {
+    // calcualte interpolated field value at position, in cartesian coordinates
+    double Bz = Bz_interp.interp(position.Rho(), position.Z());
+    double Br = Br_interp.interp(position.Rho(), position.Z());
+    // handle case where R=0 -- R=X
+    if (position.Rho() < 1e-6) {
+      return VEC3(Br, 0., Bz);
+    }
+    else {
+      return VEC3(Br*position.X()/position.Rho(), Br*position.Y()/position.Rho(), Bz);
+    }
+  }
+
+  CylBFieldMap::Grad CylBFieldMap::fieldGrad(VEC3 const& position) const {
+    // calculate gradient matrix at position, in cartesian coordinates
+    // calculate needed field and gradient values
+    double Br = Br_interp.interp(position.Rho(), position.Z());
+    VEC dBz = Bz_interp.gradient(position.Rho(), position.Z());
+    VEC dBr = Br_interp.gradient(position.Rho(), position.Z());
+    // vector to fill, will instantiate final Grad
+    VEC dBi(9);
+    // handle case where R=0 -- R=X, dR/dX=1, dR/dY=0
+    if (position.Rho() < 1e-6) {
+      dBi = VEC{dBr[0], 0., dBr[1],
+      0.,0.,0.,
+      dBz[0], 0., dBz[1]};
+    }
+    else {
+      // store values that are calculated multiple times
+      double xr=position.X()/position.Rho(), yr=position.Y()/position.Rho();
+      double xryr = xr*yr, xrxr=xr*xr, yryr=yr*yr;
+      double rinv = 1/position.Rho();
+      dBi = VEC{dBr[0]*xrxr + Br * rinv*(1 - xrxr),
+        dBr[0]*xryr + Br * (- xryr * rinv),
+        xr * dBr[1],
+        dBr[0]*xryr + Br * (- xryr * rinv),
+        dBr[0]*yryr + Br * rinv*(1 - yryr),
+        yr * dBr[1],
+        dBz[0]*xr,dBz[0]*yr,dBz[1]};
+    }
+    Grad retval(dBi.begin(), dBi.end());
+    return retval;
+  }
+
+  VEC3 CylBFieldMap::fieldDeriv(VEC3 const& position, VEC3 const& velocity) const {
+    Grad grad = fieldGrad(position);
+    // matrix times vector = vector
+    // VEC3 retval = grad * velocity;
+    // FIXME! Testing with using values on the diagonal
+    VEC3 retval(grad[0][0]*velocity.X(), grad[1][1]*velocity.Y(), grad[2][2]*velocity.Z());
+    return retval;
+  }
+
+  bool CylBFieldMap::inRange(VEC3 const& position) const {
+    // check if position is in range of the map values
+    bool rrange = (position.R() >= 0.) && (position.R() <= rMax());
+    bool zrange = (position.Z() >= zMin()) && (position.Z() <= zMax());
+    return rrange && zrange;
+  }
+}

--- a/General/CylBFieldMap.cc
+++ b/General/CylBFieldMap.cc
@@ -4,9 +4,6 @@ namespace KinKal{
   using VEC = std::vector<double>;
   using MAT = std::vector<std::vector<double>>;
   
-  // CylBFieldMap::CylBFieldMap(std::string const& file)
-  //   : B_dat(file), Br_interp(B_dat.r(), B_dat.z(), B_dat.Br()),
-  //   Bz_interp(B_dat.r(), B_dat.z(), B_dat.Bz()) {}
   CylBFieldMap::CylBFieldMap(std::string const& file)
     : B_dat(file), Br_interp(B_dat.r_, B_dat.z_, B_dat.Br_),
     Bz_interp(B_dat.r_, B_dat.z_, B_dat.Bz_) {}

--- a/General/CylBFieldMap.hh
+++ b/General/CylBFieldMap.hh
@@ -1,0 +1,40 @@
+#ifndef KinKal_CylBFieldMap_hh
+#define KinKal_CylBFieldMap_hh
+
+#include "KinKal/General/CylBMap.hh"
+#include "KinKal/General/InterpBilinear.hh"
+#include "KinKal/General/BFieldMap.hh"
+
+namespace KinKal {
+  class CylBFieldMap : public BFieldMap {
+    public:
+      using VEC = std::vector<double>;
+      using MAT = std::vector<std::vector<double>>;
+      CylBFieldMap(std::string const& file); // supply data file
+      VEC3 fieldVect(VEC3 const& position) const override;
+      Grad fieldGrad(VEC3 const& position) const override;
+      VEC3 fieldDeriv(VEC3 const& position, VEC3 const& velocity) const override;
+      bool inRange(VEC3 const& position) const override;
+      // TO DO!
+      void print(std::ostream& os=std::cout) const override {
+        os << "Cylindrically symmetric Bfield with boundaries z=[" << zMin() << ", " << zMax() << "] and r=["
+          << rMin() << ", " << rMax() << "] with " << B_dat.ntot_
+          << " field values from (lower left, upper left): Br=(" << B_dat.Br_.front().front() << ", "
+          << B_dat.Br_.back().back() << ") Tesla and Bz=(" << B_dat.Bz_.front().front() << ", "
+          << B_dat.Bz_.back().back() << ") Tesla" << std::endl;
+      }
+      virtual ~CylBFieldMap(){}
+      // disallow copy and equivalence
+      CylBFieldMap(CylBFieldMap const& ) = delete;
+      CylBFieldMap& operator =(CylBFieldMap const& ) = delete;
+      // getters
+      double zMax() const { return B_dat.z_.back(); }
+      double zMin() const { return B_dat.z_.front(); }
+      double rMax() const { return B_dat.r_.back(); }
+      double rMin() const { return B_dat.r_.front(); }
+    private:
+      const CylBMap B_dat;
+      const InterpBilinear Br_interp, Bz_interp;
+  };
+}
+#endif

--- a/General/CylBMap.cc
+++ b/General/CylBMap.cc
@@ -1,0 +1,119 @@
+#include "KinKal/General/CylBMap.hh"
+
+#include <fstream>
+#include <sstream>
+#include <math.h>
+
+namespace KinKal{
+  
+  double parse_param_double(const std::string& line, const std::string& substring) {
+    // split up grid parameter expected to be a double
+    std::size_t i = line.find(substring)+substring.size();
+    std::size_t j = line.find(' ', i);
+    std::size_t d = j-i;
+    return std::stod(line.substr(i, d));
+  }
+
+  int parse_param_int(const std::string& line, const std::string& substring) {
+    // split up grid parameter expected to be an int
+    std::size_t i = line.find(substring)+substring.size();
+    std::size_t j = line.find(' ', i);
+    std::size_t d = j-i;
+    return std::stoi(line.substr(i, d));
+  }
+
+  CylBMap::CylBMap(const std::string& file) {
+    // read in data from a file
+    ntot_ = 0; // track number of lines
+    std::string line;
+    std::ifstream stream(file);
+    while (std::getline(stream, line))
+      ++ntot_;
+    stream.close();
+    // loop through  again, saving data
+    // first sift through header
+    stream.open(file);
+    std::string const data_flag="data";
+    std::string const grid_flag="grid";
+    double R0=0., Z0=0., dR=0., dZ=0.;
+    int nR=0, nZ=0;
+    bool grid_parsed=false;
+    while (line.substr(0, 4) != data_flag)
+    {
+      // get the next line
+      std::getline(stream, line);
+      // parse grid, if parameters in line
+      if (line.substr(0, 4) == grid_flag)
+      {
+        if (grid_parsed) throw std::invalid_argument("multiple grid parameter lines found!");
+        R0 = parse_param_double(line, "R0=");
+        Z0 = parse_param_double(line, "Z0=");
+        nR = parse_param_int(line, "nR=");
+        nZ = parse_param_int(line, "nZ=");
+        dR = parse_param_double(line, "dR=");
+        dZ = parse_param_double(line, "dZ=");
+        grid_parsed=true;
+      }
+      // decrease data count
+      --ntot_;
+    }
+    // throw if no grid parameters found
+    if (!grid_parsed) throw std::invalid_argument("no grid parameters found in data file!");
+    // construct r and z vectors from grid parameters
+    m_ = nR;
+    n_ = nZ;
+    int ntot_exp = m_*n_;
+    if (ntot_ != ntot_exp) throw std::invalid_argument("number of data does not match expected, based on grid parameters");
+    r_.resize(m_);
+    z_.resize(n_);
+    // set r and z from grid parameters
+    for (int i=0; i<m_; i++){
+      r_[i] = R0 + i * dR;
+    }
+    for (int j=0; j<n_; j++){
+      z_[j] = Z0 + j * dZ;
+    }
+    // allocate matrices
+    // resize outer vectors
+    Br_.resize(m_);
+    Bz_.resize(m_);
+    // resize inner vectors
+    for (int i=0; i<m_; i++){
+      Br_[i].resize(n_);
+      Bz_[i].resize(n_);
+    }
+    // loop through data lines
+    double temp, delta_pos, z_temp, r_temp;
+    int step=0, i=0, j=0;
+    while(std::getline(stream, line)) {
+      i = step / n_;
+      j = step % n_;
+      std::istringstream iss(line);
+      // grab r & z values
+      iss >> temp;
+      r_temp = temp;
+      iss >> temp;
+      z_temp = temp;
+      // grab field values
+      iss >> temp;
+      Br_[i][j] = temp;
+      iss >> temp;
+      Bz_[i][j] = temp;
+      // check that r and z grid values are correct
+      delta_pos = pow(pow(r_temp-r_[i], 2) + pow(z_temp-z_[j], 2), 0.5);
+      if(std::abs(delta_pos) > 1e-5) throw std::invalid_argument("field spacing isn't uniform! dist="+
+        std::to_string(delta_pos)+" for line i="+ std::to_string(i)+", j="+std::to_string(j)+
+        ", step="+std::to_string(step));
+      // increment
+      step++;
+    }
+    // Shrink to fit -- fixes issues with passing in values to InterpBilinear
+    r_.shrink_to_fit(), z_.shrink_to_fit(); 
+    Br_.shrink_to_fit(), Bz_.shrink_to_fit();
+    // shrink inner vectors
+    for (int i=0; i<m_; i++){
+      Br_[i].shrink_to_fit();
+      Bz_[i].shrink_to_fit();
+    }
+  }
+}

--- a/General/CylBMap.hh
+++ b/General/CylBMap.hh
@@ -1,0 +1,20 @@
+#ifndef KinKal_CylBMap_hh
+#define KinKal_CylBMap_hh
+// "dumb" data class to do load and store Br, Bz grid values. This object will be used by CylBFieldMap interface.
+#include <string>
+#include<vector>
+
+namespace KinKal {
+  class CylBMap {
+    public:
+      using VEC = std::vector<double>;
+      using MAT = std::vector<std::vector<double>>;
+      CylBMap(const std::string& file);
+    private:
+      int m_, n_, ntot_;
+      VEC r_, z_;
+      MAT Br_, Bz_;
+      friend class CylBFieldMap;
+  };
+}
+#endif

--- a/General/InterpBilinear.cc
+++ b/General/InterpBilinear.cc
@@ -1,0 +1,48 @@
+#include "KinKal/General/InterpBilinear.hh"
+
+#include <algorithm>
+
+namespace KinKal {
+  using VEC = std::vector<double>;
+  using MAT = std::vector<std::vector<double>>;
+
+  double InterpBilinear::interp(double x1p, double x2p) const {
+    // interpolate values using bilinear interpolation formula at a point x1p, x2p
+    int i, j;
+    double yy, t, u;
+    // find i & j of point at lower left corner of square that encloses x1p,x2p
+    i = (int)((x1p-x1[0])/dx1_);
+    j = (int)((x2p-x2[0])/dx2_);
+    // make sure in available index range
+    i = std::max(0, std::min(m_-2, i));
+    j = std::max(0, std::min(n_-2, j));
+    // calculate fractional location of x1p,x2p in square of points
+    t = (x1p-x1[i])/dx1_;
+    u = (x2p-x2[j])/dx2_;
+    // bilinear interpolation 
+    yy = (1.-t)*(1.-u)*y[i][j] + t*(1.-u)*y[i+1][j] + (1.-t)*u*y[i][j+1] + t*u*y[i+1][j+1];
+    return yy;
+  }
+
+  VEC InterpBilinear::gradient(double x1p, double x2p) const {
+    // calculate derivative of interpolation function at a point x1p, x2p
+    int i, j;
+    double t, u, dtx1, dux2;
+    VEC dyxi(2);
+    // find i & j of point at lower left corner of square that encloses x1p,x2p
+    i = (int)((x1p-x1[0])/dx1_);
+    j = (int)((x2p-x2[0])/dx2_);
+    // make sure in available index range
+    i = std::max(0, std::min(m_-2, i));
+    j = std::max(0, std::min(n_-2, j));
+    // calculate fractional location of x1p,x2p in square of points
+    t = (x1p-x1[i])/dx1_;
+    u = (x2p-x2[j])/dx2_;
+    // calculate numerical derivatives
+    dtx1 = 1./(x1[i+1]-x1[i]);
+    dux2 = 1./(x2[j+1]-x2[j]);
+    dyxi[0] = dtx1 * ((1.-u)*(y[i+1][j]-y[i][j]) + u*(y[i+1][j+1]-y[i][j+1]));
+    dyxi[1] = dux2 * ((1.-t)*(y[i][j+1]-y[i][j]) + t*(y[i+1][j+1]-y[i+1][j]));
+    return dyxi; 
+  }
+}

--- a/General/InterpBilinear.hh
+++ b/General/InterpBilinear.hh
@@ -1,0 +1,23 @@
+#ifndef KinKal_InterpBilinear_hh
+#define KinKal_InterpBilinear_hh
+// class to do a 2D interpolation, which is utilized by the CylBFieldMap interface.
+#include<vector>
+
+namespace KinKal {
+  class InterpBilinear {
+    public:
+      using VEC = std::vector<double>;
+      using MAT = std::vector<VEC>;
+      InterpBilinear(const VEC &x1v, const VEC &x2v, const MAT &ym)
+        : m_(x1v.size()), n_(x2v.size()), dx1_(x1v[1]-x1v[0]), dx2_(x2v[1]-x2v[0]), x1(x1v), x2(x2v), y(ym) {}
+      double interp(double x1p, double x2p) const;
+      // the gradient vector of the interpolating function, e.g. dy/dx_i
+      VEC gradient(double x1p, double x2p) const;
+    private:
+      const int m_, n_;
+      const double dx1_, dx2_;
+      const VEC &x1, &x2;
+      const MAT &y;
+  };
+}
+#endif


### PR DESCRIPTION
CylBFieldMap inherits from BFieldMap. It uses a data class, CylBMap, to load and store data and an interpolation class, InterpBilinear, to interpolate both Br and Bz fields.