### PR TITLE
Redefining p0 in Line

### DIFF
--- a/Trajectory/GeometricLine.cc
+++ b/Trajectory/GeometricLine.cc
@@ -11,9 +11,6 @@ namespace KinKal {
   GeometricLine::GeometricLine(VEC4 const& p0, VEC3 const& svel, double length) : GeometricLine(p0.Vect(), svel, length) {}
   GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& svel, double length)  : 
     pos0_(p0), dir_(svel.Unit()), length_(length) {}
-  
-  // flipped
-  // GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& p1) : pos0_(p0), dir_((p0-p1).Unit()), length_((p1-p0).R()) {}
   GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& p1) : pos0_(p0), dir_((p1-p0).Unit()), length_((p1-p0).R()) {}
 
   VEC3 GeometricLine::position3(double distance) const {
@@ -21,8 +18,6 @@ namespace KinKal {
   }
 
   double GeometricLine::DOCA(VEC3 const& point) const {
-    // flipped
-    // return (point - pos0_).Dot(dir_);
     return (pos0_ - point).Dot(dir_);
   }
 

--- a/Trajectory/GeometricLine.cc
+++ b/Trajectory/GeometricLine.cc
@@ -9,16 +9,21 @@ using namespace ROOT::Math;
 
 namespace KinKal {
   GeometricLine::GeometricLine(VEC4 const& p0, VEC3 const& svel, double length) : GeometricLine(p0.Vect(), svel, length) {}
-  GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& svel, double length )  : 
+  GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& svel, double length)  : 
     pos0_(p0), dir_(svel.Unit()), length_(length) {}
-  GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& p1) : pos0_(p0), dir_((p0-p1).Unit()), length_((p1-p0).R()) {}
+  
+  // flipped
+  // GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& p1) : pos0_(p0), dir_((p0-p1).Unit()), length_((p1-p0).R()) {}
+  GeometricLine::GeometricLine(VEC3 const& p0, VEC3 const& p1) : pos0_(p0), dir_((p1-p0).Unit()), length_((p1-p0).R()) {}
 
   VEC3 GeometricLine::position3(double distance) const {
     return pos0_ + distance*dir_;
   }
 
   double GeometricLine::DOCA(VEC3 const& point) const {
-    return (point - pos0_).Dot(dir_);
+    // flipped
+    // return (point - pos0_).Dot(dir_);
+    return (pos0_ - point).Dot(dir_);
   }
 
   void GeometricLine::print(std::ostream& ost, int detail) const {

--- a/Trajectory/GeometricLine.hh
+++ b/Trajectory/GeometricLine.hh
@@ -15,9 +15,6 @@ namespace KinKal {
       GeometricLine(VEC3 const& p0, VEC3 const& p1);
       // accessors
       // signal ends at pos0
-      // flipped
-      // VEC3 startPosition() const { return pos0_ - length_*dir_; }
-      // VEC3 const& endPosition() const { return pos0_; }
       VEC3 const& startPosition() const { return pos0_; }
       VEC3 endPosition() const { return pos0_ + length_*dir_; }
       double length() const { return length_; }

--- a/Trajectory/GeometricLine.hh
+++ b/Trajectory/GeometricLine.hh
@@ -15,8 +15,11 @@ namespace KinKal {
       GeometricLine(VEC3 const& p0, VEC3 const& p1);
       // accessors
       // signal ends at pos0
-      VEC3 startPosition() const { return pos0_ - length_*dir_; }
-      VEC3 const& endPosition() const { return pos0_ ; }
+      // flipped
+      // VEC3 startPosition() const { return pos0_ - length_*dir_; }
+      // VEC3 const& endPosition() const { return pos0_; }
+      VEC3 const& startPosition() const { return pos0_; }
+      VEC3 endPosition() const { return pos0_ + length_*dir_; }
       double length() const { return length_; }
       VEC3 const& direction() const { return dir_; }
       // Distance of Closest Approach to a point

--- a/Trajectory/Line.cc
+++ b/Trajectory/Line.cc
@@ -36,11 +36,9 @@ namespace KinKal {
   }
 
   void Line::print(std::ostream& ost, int detail) const {
-    // switched from endPosition() to startPosition()
-    ost << " Line, intial position " << startPosition()
+    ost << " Line, initial position " << startPosition()
     << " t0 " << t0()
     << " direction " << direction() << endl;
-    //<< " speed " << speed() << endl;
   }
 
   std::ostream& operator <<(std::ostream& ost, Line const& tline) {

--- a/Trajectory/Line.cc
+++ b/Trajectory/Line.cc
@@ -36,7 +36,8 @@ namespace KinKal {
   }
 
   void Line::print(std::ostream& ost, int detail) const {
-    ost << " Line, intial position " << endPosition()
+    // switched from endPosition() to startPosition()
+    ost << " Line, intial position " << startPosition()
     << " t0 " << t0()
     << " direction " << direction() << endl;
     //<< " speed " << speed() << endl;

--- a/Trajectory/Line.hh
+++ b/Trajectory/Line.hh
@@ -24,8 +24,9 @@ namespace KinKal {
       double t0() const { return t0_; }
       double& t0() { return t0_; } // detector updates need to refine t0
       // signal ends at pos0
-      VEC3 startPosition() const { return gline_.startPosition(); }
-      VEC3 const& endPosition() const { return gline_.endPosition() ; }
+      // flipped: signal starts at pos0  (interchanged the const&)
+      VEC3 const& startPosition() const { return gline_.startPosition(); }
+      VEC3 endPosition() const { return gline_.endPosition() ; }
       double speed(double time) const { return d2t_->speed(d2t_->distance(time-t0_)); }
       double length() const { return gline_.length(); }
       VEC3 const& direction() const { return gline_.direction(); }

--- a/Trajectory/Line.hh
+++ b/Trajectory/Line.hh
@@ -24,7 +24,6 @@ namespace KinKal {
       double t0() const { return t0_; }
       double& t0() { return t0_; } // detector updates need to refine t0
       // signal ends at pos0
-      // flipped: signal starts at pos0  (interchanged the const&)
       VEC3 const& startPosition() const { return gline_.startPosition(); }
       VEC3 endPosition() const { return gline_.endPosition() ; }
       double speed(double time) const { return d2t_->speed(d2t_->distance(time-t0_)); }


### PR DESCRIPTION
Switched the definition of p0 to be the starting point as opposed to the end point in GeometricLine and Line. More changes might be needed in the codebase to support this redefinition.