### PR TITLE
enable c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ endif()
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}" )
 
 
-# enable c++17 standard
-set(CMAKE_CXX_STANDARD 17)
+# enable c++20 standard
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # make sure CMake is able to find ROOT


### PR DESCRIPTION
Enable c++20 this is done unconditionally.  Ideally it should test on the root configuration and decided on the c++ standard based on that. 
