### PR TITLE
Rule3 231110

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ add_compile_options(
   "-Woverloaded-virtual"
   "-fdiagnostics-color=always"
   "-Werror=sign-compare"
+  "-Wdeprecated-copy"
   #    "-Wshadow"
   # debug flags
   "$<$<CONFIG:DEBUG>:-O0;-g;-ftrapping-math>"

--- a/Examples/BFieldInfo.hh
+++ b/Examples/BFieldInfo.hh
@@ -5,7 +5,6 @@
 namespace KinKal {
   struct BFieldInfo {
     BFieldInfo(){};
-    ~BFieldInfo(){};
     Int_t active_;
     Float_t time_, range_;
     static std::string leafnames() { return std::string("active/i:time/f:range/f"); }

--- a/Examples/MaterialInfo.hh
+++ b/Examples/MaterialInfo.hh
@@ -6,7 +6,6 @@ namespace KinKal {
   struct MaterialInfo {
     MaterialInfo(): active_(false), nxing_(-1), time_(0.0), dmomf_(0.0),
     momvar_(0.0), perpvar_(0.0), doca_(0.0), docavar_(0.0), dirdot_(0.0){};
-    ~MaterialInfo(){};
     Int_t active_, nxing_;
     Float_t time_, dmomf_, momvar_, perpvar_;
     Float_t doca_, docavar_, dirdot_;

--- a/Examples/ParticleTrajectoryInfo.hh
+++ b/Examples/ParticleTrajectoryInfo.hh
@@ -5,7 +5,6 @@
 namespace KinKal {
   struct ParticleTrajectoryInfo {
     ParticleTrajectoryInfo(){};
-    ~ParticleTrajectoryInfo(){};
     Float_t time_, dperp_, dt_;
     static std::string leafnames() { return std::string("time/f:dperp/f:dt/f"); }
   };

--- a/General/FitData.hh
+++ b/General/FitData.hh
@@ -19,6 +19,8 @@ namespace KinKal {
       FitData() {}
       // copy with optional inversion
       FitData(FitData const& tdata, bool inv=false) : vec_(tdata.vec_), mat_(tdata.mat_) { if (inv) invert(); }
+      FitData& operator=(const FitData &) = default;
+      ~FitData() = default;
       // accessors
       DVEC const& vec() const { return vec_; }
       DMAT const& mat() const { return mat_; }

--- a/Trajectory/KinematicLine.hh
+++ b/Trajectory/KinematicLine.hh
@@ -60,7 +60,7 @@ class KinematicLine {
     explicit KinematicLine(ParticleStateEstimate const& pstate, VEC3 const& bnom, TimeRange const& range=TimeRange());
 
 
-    virtual ~KinematicLine() {}
+    virtual ~KinematicLine() = default;
 
     // particle momentum as a function of time
     MOM4 momentum4(double time) const;


### PR DESCRIPTION
For FitData, I think the warning is triggered because the constructor with a rhs and a bool has a default for the bool, so the constructor acts like a copy constructor.  The rest should be straightforward