### PR TITLE
Add intersection convergence testing

### DIFF
--- a/Geometry/Intersect.hh
+++ b/Geometry/Intersect.hh
@@ -64,7 +64,7 @@ namespace KinKal {
               unsigned iprev = (iconv + 1) % 2; // previous cycle (that we just finished)
               if(sumdist[iprev]/sumdist[icur] > 0.5) {
                 // claim non-convergence if the sum distance hasn't decreased by at least a factor of 2 between cycles
-                std::cout << "Non-converged step intersection ray inter dist " << dist << " avg " << sumdist[iprev] << " prev avg " << sumdist[icur] << std::endl;
+                // std::cout << "Non-converged step intersection ray inter dist " << dist << " avg " << sumdist[iprev] << " prev avg " << sumdist[icur] << std::endl;
                 return retval; // failed
               }
             }

--- a/Geometry/ParticleTrajectoryIntersect.hh
+++ b/Geometry/ParticleTrajectoryIntersect.hh
@@ -8,7 +8,7 @@
 #include "KinKal/Geometry/Intersection.hh"
 #include "KinKal/Geometry/Intersect.hh"
 namespace KinKal {
-//  Find first intersection of a particle trajectory in the specified range.  This is a generic implementation
+  //  Find first intersection of a particle trajectory in the specified range.  This is a generic implementation
   template <class KTRAJ, class SURF> Intersection pIntersect(ParticleTrajectory<KTRAJ> const& ptraj, SURF const& surf, TimeRange trange, double tstart, double tol,TimeDir tdir = TimeDir::forwards) {
     Intersection retval;
     // loop over pieces, and test the ones in range
@@ -41,7 +41,7 @@ namespace KinKal {
 
   // Helix-based particle trajectory intersect implementation with a plane
   template <class HELIX> Intersection phpIntersect(ParticleTrajectory<HELIX> const& phelix, KinKal::Plane const& plane, TimeRange trange ,double tol,TimeDir tdir = TimeDir::forwards) {
-    double tstart = tdir == TimeDir::forwards ? trange.begin() : trange.end();
+    double tstart = trange.mid();
     auto const& midhelix = phelix.nearestPiece(tstart);
     auto axis = midhelix.axis(midhelix.range().mid());
     if(tdir == TimeDir::backwards)axis.reverse();
@@ -56,7 +56,7 @@ namespace KinKal {
   }
 
   template < class HELIX> Intersection phcIntersect( ParticleTrajectory<HELIX> const& phelix, KinKal::Cylinder const& cyl, TimeRange trange ,double tol, TimeDir tdir = TimeDir::forwards) {
-    double tstart = tdir == TimeDir::forwards ? trange.begin() : trange.end();
+    double tstart = trange.mid();
     auto const& midhelix = phelix.nearestPiece(tstart);
     auto axis = midhelix.axis(midhelix.range().mid());
     double dist; // distance to the midplane
@@ -70,7 +70,7 @@ namespace KinKal {
   }
 
   template < class HELIX> Intersection phfIntersect( ParticleTrajectory<HELIX> const& phelix, KinKal::Frustrum const& fru, TimeRange trange ,double tol, TimeDir tdir = TimeDir::forwards) {
-    double tstart = tdir == TimeDir::forwards ? trange.begin() : trange.end();
+    double tstart = trange.mid();
     auto const& midhelix = phelix.nearestPiece(tstart);
     auto axis = midhelix.axis(midhelix.range().mid());
     double dist; // distance to the midplane


### PR DESCRIPTION
This fixes an infinite loop problem when a trajectory approaches parabolically to a surface. It also improves the search for the correct particle trajectory segment when intersecting.