### PR TITLE
Implement Track<> copy-constructor and backing graph-copy infrastructure

### DIFF
--- a/Detector/ElementXing.hh
+++ b/Detector/ElementXing.hh
@@ -4,6 +4,7 @@
 //  Describe the material effects of a particle crossing a detector element (piece of the detector)
 //  Used in the kinematic Kalman fit
 //
+#include "KinKal/General/CloneContext.hh"
 #include "KinKal/General/MomBasis.hh"
 #include "KinKal/Detector/MaterialXing.hh"
 #include "KinKal/Trajectory/ParticleTrajectory.hh"
@@ -19,6 +20,9 @@ namespace KinKal {
       using KTRAJPTR = std::shared_ptr<KTRAJ>;
       ElementXing() {}
       virtual ~ElementXing() {}
+      // clone op for reinstantiation
+      ElementXing(ElementXing const& rhs) = default;
+      virtual std::shared_ptr< ElementXing<KTRAJ> > clone(CloneContext&) const = 0;
       virtual void updateReference(PTRAJ const& ptraj) = 0; // update the trajectory reference
       virtual void updateState(MetaIterConfig const& config,bool first) =0; // update the state according to this meta-config
       virtual Parameters params() const =0; // parameter change induced by this element crossing WRT the reference parameters going forwards in time

--- a/Detector/ElementXing.hh
+++ b/Detector/ElementXing.hh
@@ -12,6 +12,8 @@
 #include <vector>
 #include <array>
 #include <ostream>
+#include <stdexcept>
+#include <string>
 
 namespace KinKal {
   template <class KTRAJ> class ElementXing {
@@ -22,7 +24,7 @@ namespace KinKal {
       virtual ~ElementXing() {}
       // clone op for reinstantiation
       ElementXing(ElementXing const& rhs) = default;
-      virtual std::shared_ptr< ElementXing<KTRAJ> > clone(CloneContext&) const = 0;
+      virtual std::shared_ptr< ElementXing<KTRAJ> > clone(CloneContext&) const;
       virtual void updateReference(PTRAJ const& ptraj) = 0; // update the trajectory reference
       virtual void updateState(MetaIterConfig const& config,bool first) =0; // update the state according to this meta-config
       virtual Parameters params() const =0; // parameter change induced by this element crossing WRT the reference parameters going forwards in time
@@ -43,6 +45,14 @@ namespace KinKal {
       double radiationFraction() const;
     private:
   };
+
+  // cloning requires domain knowledge of pointer members of the cloned object,
+  // which must be reassigned explicitly; the default action is thus to throw
+  // an error if a clone routine has not been explicitly provided.
+  template<class KTRAJ> std::shared_ptr< ElementXing<KTRAJ> > ElementXing<KTRAJ>::clone(CloneContext&) const{
+    std::string msg = "Attempt to clone KinKal::Hit subclass with no clone() implementation";
+    throw std::runtime_error(msg);
+  }
 
   template <class KTRAJ> void ElementXing<KTRAJ>::momentumChange(SVEC3& dmom, SMAT& dmomvar) const {
     // compute the parameter effect for forwards time

--- a/Detector/Hit.hh
+++ b/Detector/Hit.hh
@@ -12,6 +12,8 @@
 #include "KinKal/Fit/MetaIterConfig.hh"
 #include <memory>
 #include <ostream>
+#include <stdexcept>
+#include <string>
 
 namespace KinKal {
   template <class KTRAJ> class Hit {
@@ -24,7 +26,7 @@ namespace KinKal {
       Hit(Hit const& ) = delete;
       Hit& operator =(Hit const& ) = delete;
       // clone op for reinstantiation
-      virtual std::shared_ptr< Hit<KTRAJ> > clone(CloneContext&) const = 0;
+      virtual std::shared_ptr< Hit<KTRAJ> > clone(CloneContext&) const;
      // hits may be active (used in the fit) or inactive; this is a pattern recognition feature
       virtual bool active() const =0;
       virtual unsigned nDOF() const=0;
@@ -47,6 +49,14 @@ namespace KinKal {
       // unbiased least-squares distance to reference parameters
       Chisq chisquared() const;
   };
+
+  // cloning requires domain knowledge of pointer members of the cloned object,
+  // which must be reassigned explicitly; the default action is thus to throw
+  // an error if a clone routine has not been explicitly provided.
+  template<class KTRAJ> std::shared_ptr< Hit<KTRAJ> > Hit<KTRAJ>::clone(CloneContext& context) const{
+    std::string msg = "Attempt to clone KinKal::Hit subclass with no clone() implementation";
+    throw std::runtime_error(msg);
+  }
 
   template<class KTRAJ> Parameters Hit<KTRAJ>::unbiasedParameters() const {
     if(active()){

--- a/Detector/Hit.hh
+++ b/Detector/Hit.hh
@@ -4,6 +4,7 @@
 //  Base class to describe a measurement that constrains some aspect of the track fit
 //  The constraint is expressed as a weight WRT a set of reference parameters.
 //
+#include "KinKal/General/CloneContext.hh"
 #include "KinKal/General/Weights.hh"
 #include "KinKal/General/Parameters.hh"
 #include "KinKal/General/Chisq.hh"
@@ -22,6 +23,8 @@ namespace KinKal {
       // disallow copy and equivalence
       Hit(Hit const& ) = delete;
       Hit& operator =(Hit const& ) = delete;
+      // clone op for reinstantiation
+      virtual std::shared_ptr< Hit<KTRAJ> > clone(CloneContext&) const = 0;
      // hits may be active (used in the fit) or inactive; this is a pattern recognition feature
       virtual bool active() const =0;
       virtual unsigned nDOF() const=0;

--- a/Detector/ParameterHit.hh
+++ b/Detector/ParameterHit.hh
@@ -15,6 +15,21 @@ namespace KinKal {
       using PTRAJ = ParticleTrajectory<KTRAJ>;
       using KTRAJPTR = std::shared_ptr<KTRAJ>;
 
+      // clone op for reinstantiation
+      ParameterHit(ParameterHit<KTRAJ> const& rhs):
+          time_(rhs.time()),
+          params_(rhs.constraintParameters()),
+          pweight_(rhs.pweight()),
+          weight_(rhs.weight()),
+          pmask_(rhs.pmask()),
+          mask_(rhs.mask()),
+          ncons_(rhs.ncons()){
+        /**/
+      };
+      std::shared_ptr< Hit<KTRAJ> > clone(CloneContext& context) const override{
+        auto rv = std::make_shared< ParameterHit<KTRAJ> >(*this);
+        return rv;
+      };
       // Hit interface overrrides
       bool active() const override { return ncons_ > 0; }
       Chisq chisq(Parameters const& pdata) const override;
@@ -32,6 +47,10 @@ namespace KinKal {
       unsigned nDOF() const override { return ncons_; }
       Parameters const& constraintParameters() const { return params_; }
       PMASK const& constraintMask() const { return pmask_; }
+      Weights pweight() const { return pweight_; };
+      PMASK pmask() const { return pmask_; };
+      DMAT mask() const { return mask_; }
+      unsigned ncons() const { return ncons_; };
     private:
       double time_; // time of this constraint: must be supplied on construction and does not change
       KTRAJPTR reftraj_; // reference WRT this hits weight was calculated

--- a/Detector/ParameterHit.hh
+++ b/Detector/ParameterHit.hh
@@ -15,17 +15,18 @@ namespace KinKal {
       using PTRAJ = ParticleTrajectory<KTRAJ>;
       using KTRAJPTR = std::shared_ptr<KTRAJ>;
 
-      // clone op for reinstantiation
+      // copy constructor
       ParameterHit(ParameterHit<KTRAJ> const& rhs):
           time_(rhs.time()),
           params_(rhs.constraintParameters()),
-          pweight_(rhs.pweight()),
+          pweight_(rhs.parameterWeights()),
           weight_(rhs.weight()),
-          pmask_(rhs.pmask()),
-          mask_(rhs.mask()),
-          ncons_(rhs.ncons()){
+          pmask_(rhs.constraintMask()),
+          mask_(rhs.maskMatrix()),
+          ncons_(rhs.numConstrainedParameters()){
         /**/
       };
+      // clone op for reinstantiation
       std::shared_ptr< Hit<KTRAJ> > clone(CloneContext& context) const override{
         auto rv = std::make_shared< ParameterHit<KTRAJ> >(*this);
         return rv;
@@ -47,10 +48,9 @@ namespace KinKal {
       unsigned nDOF() const override { return ncons_; }
       Parameters const& constraintParameters() const { return params_; }
       PMASK const& constraintMask() const { return pmask_; }
-      Weights pweight() const { return pweight_; };
-      PMASK pmask() const { return pmask_; };
-      DMAT mask() const { return mask_; }
-      unsigned ncons() const { return ncons_; };
+      Weights parameterWeights() const { return pweight_; };
+      DMAT maskMatrix() const { return mask_; }
+      unsigned numConstrainedParameters() const { return ncons_; };
     private:
       double time_; // time of this constraint: must be supplied on construction and does not change
       KTRAJPTR reftraj_; // reference WRT this hits weight was calculated

--- a/Detector/ResidualHit.hh
+++ b/Detector/ResidualHit.hh
@@ -10,6 +10,10 @@ namespace KinKal {
 
   template <class KTRAJ> class ResidualHit : public Hit<KTRAJ> {
     public:
+      // clone op for reinstantiation
+      ResidualHit(ResidualHit<KTRAJ> const& rhs): weight_(rhs.weight()){
+        /**/
+      };
       // override of some Hit interface.  Subclasses must still implement update and material methods
       using HIT = Hit<KTRAJ>;
       using PTRAJ = ParticleTrajectory<KTRAJ>;

--- a/Detector/ResidualHit.hh
+++ b/Detector/ResidualHit.hh
@@ -10,7 +10,7 @@ namespace KinKal {
 
   template <class KTRAJ> class ResidualHit : public Hit<KTRAJ> {
     public:
-      // clone op for reinstantiation
+      // copy constructor
       ResidualHit(ResidualHit<KTRAJ> const& rhs): weight_(rhs.weight()){
         /**/
       };

--- a/Examples/ScintHit.hh
+++ b/Examples/ScintHit.hh
@@ -17,18 +17,28 @@ namespace KinKal {
       using RESIDHIT = ResidualHit<KTRAJ>;
       using HIT = Hit<KTRAJ>;
       using KTRAJPTR = std::shared_ptr<KTRAJ>;
-      // clone op for reinstantiation
+      // copy constructor
       ScintHit(ScintHit<KTRAJ> const& rhs):
           ResidualHit<KTRAJ>(rhs),
           saxis_(rhs.sensorAxis()),
           tvar_(rhs.timeVariance()),
           wvar_(rhs.widthVariance()),
-          tpca_(rhs.closestApproach()),
+          tpca_(
+                rhs.closestApproach().particleTraj(),
+                saxis_,
+                rhs.closestApproach().hint(),
+                rhs.closestApproach().precision()
+          ),
           rresid_(rhs.refResidual()){
         /**/
       };
+      // clone op for reinstantiation
       std::shared_ptr< Hit<KTRAJ> > clone(CloneContext& context) const override{
         auto rv = std::make_shared< ScintHit<KTRAJ> >(*this);
+        auto ca = rv->closestApproach();
+        auto trajectory = std::make_shared<KTRAJ>(ca.particleTraj());
+        ca.setTrajectory(trajectory);
+        rv->setClosestApproach(ca);
         return rv;
       };
       // ResidualHit interface implementation
@@ -54,6 +64,9 @@ namespace KinKal {
       double wvar_; // variance in transverse position of the sensor/measurement in mm.  Assumes cylindrical error, could be more general
       CA tpca_; // reference time and position of closest approach to the axis
       Residual rresid_; // residual WRT most recent reference parameters
+
+      // modifiers to support cloning
+      void setClosestApproach(const CA& ca){ tpca_ = ca; }
   };
 
   template <class KTRAJ> ScintHit<KTRAJ>::ScintHit(PCA const& pca, double tvar, double wvar) :

--- a/Examples/ScintHit.hh
+++ b/Examples/ScintHit.hh
@@ -17,6 +17,20 @@ namespace KinKal {
       using RESIDHIT = ResidualHit<KTRAJ>;
       using HIT = Hit<KTRAJ>;
       using KTRAJPTR = std::shared_ptr<KTRAJ>;
+      // clone op for reinstantiation
+      ScintHit(ScintHit<KTRAJ> const& rhs):
+          ResidualHit<KTRAJ>(rhs),
+          saxis_(rhs.sensorAxis()),
+          tvar_(rhs.timeVariance()),
+          wvar_(rhs.widthVariance()),
+          tpca_(rhs.closestApproach()),
+          rresid_(rhs.refResidual()){
+        /**/
+      };
+      std::shared_ptr< Hit<KTRAJ> > clone(CloneContext& context) const override{
+        auto rv = std::make_shared< ScintHit<KTRAJ> >(*this);
+        return rv;
+      };
       // ResidualHit interface implementation
       unsigned nResid() const override { return 1; } // 1 time residual
       Residual const& refResidual(unsigned ires=0) const override;

--- a/Examples/SimpleWireHit.hh
+++ b/Examples/SimpleWireHit.hh
@@ -81,8 +81,7 @@ namespace KinKal {
       auto const& residuals() const { return rresid_; }
       double tot() const { return tot_; }
       double totVariance() const { return totvar_; }
-      // other accessors
-      void setClosestApproach(const CA& ca){ ca_ = ca; }
+
     private:
       BFieldMap const& bfield_; // drift calculation requires the BField for ExB effects
       WireHitState whstate_; // current state
@@ -100,6 +99,9 @@ namespace KinKal {
       double rcell_; // straw radius
       int id_; // id
       void updateResiduals();
+
+      // modifiers to support cloning
+      void setClosestApproach(const CA& ca){ ca_ = ca; }
   };
 
   //trivial 'updater' that sets the wire hit state to null

--- a/Examples/StrawXing.hh
+++ b/Examples/StrawXing.hh
@@ -22,7 +22,23 @@ namespace KinKal {
       StrawXing(PCA const& pca, StrawMaterial const& smat);
       virtual ~StrawXing() {}
       // copy constructor
-      StrawXing(StrawXing const& rhs) = default;
+      StrawXing(StrawXing const& rhs):
+          ElementXing<KTRAJ>(rhs),
+          axis_(rhs.axis_),
+          smat_(rhs.smat_),
+          tpca_(
+                rhs.closestApproach().particleTraj(),
+                axis_,
+                rhs.closestApproach().hint(),
+                rhs.closestApproach().precision()
+          ),
+          toff_(rhs.toff_),
+          sxconfig_(rhs.sxconfig_),
+          varscale_(rhs.varscale_),
+          mxings_(rhs.mxings_),
+          fparams_(rhs.fparams_){
+        /**/
+      }
       // clone op for reinstantiation
       std::shared_ptr< ElementXing<KTRAJ> > clone(CloneContext& context) const override{
         auto rv = std::make_shared< StrawXing<KTRAJ> >(*this);
@@ -46,8 +62,7 @@ namespace KinKal {
       auto const& strawMaterial() const { return smat_; }
       auto const& config() const { return sxconfig_; }
       auto precision() const { return tpca_.precision(); }
-      // other accessors
-      void setClosestApproach(const CA& ca){ tpca_ = ca; }
+
     private:
       SensorLine axis_; // straw axis, expressed as a timeline
       StrawMaterial const& smat_;
@@ -57,6 +72,9 @@ namespace KinKal {
       double varscale_; // variance scale
       std::vector<MaterialXing> mxings_;
       Parameters fparams_; // parameter change for forwards time
+
+      // modifiers to support cloning
+      void setClosestApproach(const CA& ca){ tpca_ = ca; }
   };
 
   template <class KTRAJ> StrawXing<KTRAJ>::StrawXing(PCA const& pca, StrawMaterial const& smat) :

--- a/Examples/StrawXing.hh
+++ b/Examples/StrawXing.hh
@@ -21,9 +21,9 @@ namespace KinKal {
       // construct from PCA and material
       StrawXing(PCA const& pca, StrawMaterial const& smat);
       virtual ~StrawXing() {}
-      // clone op for reinstantiation
-      // ejc TODO does typeof(tpca_) == ClosestApproach<> need a deeper clone?
+      // copy constructor
       StrawXing(StrawXing const& rhs) = default;
+      // clone op for reinstantiation
       std::shared_ptr< ElementXing<KTRAJ> > clone(CloneContext& context) const override{
         auto rv = std::make_shared< StrawXing<KTRAJ> >(*this);
         auto ca = rv->closestApproach();

--- a/Examples/StrawXing.hh
+++ b/Examples/StrawXing.hh
@@ -21,6 +21,17 @@ namespace KinKal {
       // construct from PCA and material
       StrawXing(PCA const& pca, StrawMaterial const& smat);
       virtual ~StrawXing() {}
+      // clone op for reinstantiation
+      // ejc TODO does typeof(tpca_) == ClosestApproach<> need a deeper clone?
+      StrawXing(StrawXing const& rhs) = default;
+      std::shared_ptr< ElementXing<KTRAJ> > clone(CloneContext& context) const override{
+        auto rv = std::make_shared< StrawXing<KTRAJ> >(*this);
+        auto ca = rv->closestApproach();
+        auto trajectory = std::make_shared<KTRAJ>(ca.particleTraj());
+        ca.setTrajectory(trajectory);
+        rv->setClosestApproach(ca);
+        return rv;
+      }
       // ElementXing interface
       void updateReference(PTRAJ const& ptraj) override;
       void updateState(MetaIterConfig const& config,bool first) override;
@@ -35,6 +46,8 @@ namespace KinKal {
       auto const& strawMaterial() const { return smat_; }
       auto const& config() const { return sxconfig_; }
       auto precision() const { return tpca_.precision(); }
+      // other accessors
+      void setClosestApproach(const CA& ca){ tpca_ = ca; }
     private:
       SensorLine axis_; // straw axis, expressed as a timeline
       StrawMaterial const& smat_;

--- a/Fit/Domain.hh
+++ b/Fit/Domain.hh
@@ -4,6 +4,8 @@
 //  domain used to compute magnetic field corrections. Magnetic bending not described by the intrinsic parameterization is assumed
 //  to be negligible over the domain
 //
+#include <memory>
+#include "KinKal/General/CloneContext.hh"
 #include "KinKal/General/TimeRange.hh"
 #include "KinKal/General/Vectors.hh"
 namespace KinKal {
@@ -11,6 +13,9 @@ namespace KinKal {
     public:
       Domain(double lowtime, double range, VEC3 const& bnom, double tol) : range_(lowtime,lowtime+range), bnom_(bnom), tol_(tol) {}
       Domain(TimeRange const& range, VEC3 const& bnom, double tol) : range_(range), bnom_(bnom), tol_(tol) {}
+      // clone op for reinstantiation
+      Domain(Domain const&);
+      std::shared_ptr< Domain > clone(CloneContext&) const;
       bool operator < (Domain const& other) const {return begin() < other.begin(); }
       auto const& range() const { return range_; }
       // forward range functions
@@ -25,6 +30,19 @@ namespace KinKal {
       VEC3 bnom_; // nominal BField for this domain
       double tol_; // tolerance used to create this domain
   };
+
+  // clone op for reinstantiation
+  Domain::Domain(Domain const& rhs):
+      range_(rhs.range()),
+      bnom_(rhs.bnom()),
+      tol_(rhs.tolerance()){
+    /**/
+  }
+
+  std::shared_ptr<Domain> Domain::clone(CloneContext& context) const{
+    auto rv = std::make_shared<Domain>(*this);
+    return rv;
+  }
 }
 #endif
 

--- a/Fit/DomainWall.hh
+++ b/Fit/DomainWall.hh
@@ -45,7 +45,6 @@ namespace KinKal {
       auto const& prevDomain() const { return *prev_; }
       auto const& nextDomain() const { return *next_; }
       // other accessors
-      auto const& bfield() const { return bfield_; }
       auto const& prevPtr() const { return prev_; }
       auto const& nextPtr() const { return next_; }
       auto const& fwdChange() const { return dpfwd_; }
@@ -148,7 +147,6 @@ namespace KinKal {
   // clone op for reinstantiation
   template <class KTRAJ>
   DomainWall<KTRAJ>::DomainWall(DomainWall const& rhs):
-      bfield_(rhs.bfield()),
       dpfwd_(rhs.fwdChange()),
       prevwt_(rhs.prevWeight()),
       nextwt_(rhs.nextWeight()),

--- a/Fit/DomainWall.hh
+++ b/Fit/DomainWall.hh
@@ -51,8 +51,6 @@ namespace KinKal {
       auto const& prevWeight() const { return prevwt_; }
       auto const& nextWeight() const { return nextwt_; }
       auto const& fwdCovarianceRotation() const { return dpdpdb_; }
-      void setPrevPtr(DOMAINPTR const& ptr){ prev_ = ptr; }
-      void setNextPtr(DOMAINPTR const& ptr){ next_ = ptr; }
 
     private:
       DOMAINPTR prev_, next_; // pointers to previous and next domains
@@ -60,6 +58,9 @@ namespace KinKal {
       Weights prevwt_, nextwt_; // cache of weights
       PSMAT dpdpdb_; // forward rotation of covariance matrix going in the forwards direction
 
+      // modifiers to support cloning
+      void setPrevPtr(DOMAINPTR const& ptr){ prev_ = ptr; }
+      void setNextPtr(DOMAINPTR const& ptr){ next_ = ptr; }
   };
 
   template<class KTRAJ> DomainWall<KTRAJ>::DomainWall(

--- a/Fit/DomainWall.hh
+++ b/Fit/DomainWall.hh
@@ -38,7 +38,7 @@ namespace KinKal {
       DomainWall& operator =(DomainWall const& ) = delete;
       // clone op for reinstantiation
       DomainWall(DomainWall const&);
-      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const;
+      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const override;
       // specific DomainWall interface
       // create from the domain and BField
       DomainWall(BFieldMap const& bfield,DOMAINPTR const& prevdomain,DOMAINPTR const& nextdomain, PTRAJ const& ptraj);

--- a/Fit/Effect.hh
+++ b/Fit/Effect.hh
@@ -7,6 +7,7 @@
 //
 #include "KinKal/Trajectory/ParticleTrajectory.hh"
 #include "KinKal/General/Chisq.hh"
+#include "KinKal/General/CloneContext.hh"
 #include "KinKal/Fit/FitState.hh"
 #include "KinKal/Fit/Config.hh"
 #include "KinKal/General/TimeRange.hh"
@@ -22,6 +23,8 @@ namespace KinKal {
       using PTRAJ = ParticleTrajectory<KTRAJ>;
       Effect() {}
       virtual ~Effect(){}
+      // clone op for reinstantiation
+      virtual std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const = 0;
       // Effect interface
       virtual double time() const = 0; // time of this effect
       virtual bool active() const = 0; // whether this effect is/was used in the fit

--- a/Fit/Effect.hh
+++ b/Fit/Effect.hh
@@ -14,6 +14,8 @@
 #include <array>
 #include <memory>
 #include <ostream>
+#include <stdexcept>
+#include <string>
 
 namespace KinKal {
 
@@ -24,7 +26,7 @@ namespace KinKal {
       Effect() {}
       virtual ~Effect(){}
       // clone op for reinstantiation
-      virtual std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const = 0;
+      virtual std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const;
       // Effect interface
       virtual double time() const = 0; // time of this effect
       virtual bool active() const = 0; // whether this effect is/was used in the fit
@@ -48,6 +50,14 @@ namespace KinKal {
       Effect(Effect const& ) = delete;
       Effect& operator =(Effect const& ) = delete;
   };
+
+  // cloning requires domain knowledge of pointer members of the cloned object,
+  // which must be reassigned explicitly; the default action is thus to throw
+  // an error if a clone routine has not been explicitly provided.
+  template <class KTRAJ> std::unique_ptr< Effect<KTRAJ> > Effect<KTRAJ>::clone(CloneContext& context) const{
+    std::string msg = "Attempt to clone KinKal::Effect subclass with no clone() implementation";
+    throw std::runtime_error(msg);
+  }
 
   template <class KTRAJ> std::ostream& operator <<(std::ostream& ost, Effect<KTRAJ> const& eff) {
     ost << (eff.active() ? "Active " : "Inactive ") << "time " << eff.time();

--- a/Fit/Material.hh
+++ b/Fit/Material.hh
@@ -34,7 +34,7 @@ namespace KinKal {
       Material(EXINGPTR const& exingptr, PTRAJ const& ptraj);
       // clone op for reinstantiation
       Material(Material const&);
-      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const;
+      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const override;
       // accessors
       auto const& elementXing() const { return *exingptr_; }
       auto const& elementXingPtr() const { return exingptr_; }

--- a/Fit/Material.hh
+++ b/Fit/Material.hh
@@ -32,10 +32,16 @@ namespace KinKal {
       virtual ~Material(){}
       // create from the material and a trajectory
       Material(EXINGPTR const& exingptr, PTRAJ const& ptraj);
+      // clone op for reinstantiation
+      Material(Material const&);
+      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const;
       // accessors
       auto const& elementXing() const { return *exingptr_; }
       auto const& elementXingPtr() const { return exingptr_; }
       auto const& referenceTrajectory() const { return exingptr_->referenceTrajectory(); }
+      // other accessors
+      auto const& weights() const { return nextwt_; }
+      void setElementXingPtr(EXINGPTR const& ptr){ exingptr_ = ptr; }
     private:
       EXINGPTR exingptr_; // element crossing for this effect
       Weights nextwt_; // cache of weight forwards of this effect.
@@ -142,6 +148,23 @@ namespace KinKal {
   template <class KTRAJ> std::ostream& operator <<(std::ostream& ost, Material<KTRAJ> const& kkmat) {
     kkmat.print(ost,0);
     return ost;
+  }
+
+  // clone op for reinstantiation
+  template <class KTRAJ>
+  Material<KTRAJ>::Material(Material const& rhs):
+    nextwt_(rhs.weights()){
+    /**/
+  }
+
+  template <class KTRAJ>
+  std::unique_ptr< Effect<KTRAJ> > Material<KTRAJ>::clone(CloneContext& context) const{
+    auto casted = std::make_unique< Material<KTRAJ> >(*this);
+    EXINGPTR ptr = context.get(exingptr_);
+    casted->setElementXingPtr(ptr);
+    //auto rv = std::make_unique< Effect<KTRAJ> >(casted);
+    auto rv = std::move(casted);
+    return rv;
   }
 }
 #endif

--- a/Fit/Material.hh
+++ b/Fit/Material.hh
@@ -39,12 +39,13 @@ namespace KinKal {
       auto const& elementXing() const { return *exingptr_; }
       auto const& elementXingPtr() const { return exingptr_; }
       auto const& referenceTrajectory() const { return exingptr_->referenceTrajectory(); }
-      // other accessors
       auto const& weights() const { return nextwt_; }
-      void setElementXingPtr(EXINGPTR const& ptr){ exingptr_ = ptr; }
     private:
       EXINGPTR exingptr_; // element crossing for this effect
       Weights nextwt_; // cache of weight forwards of this effect.
+
+      // modifiers to support cloning
+      void setElementXingPtr(EXINGPTR const& ptr){ exingptr_ = ptr; }
   };
 
   template<class KTRAJ> Material<KTRAJ>::Material(EXINGPTR const& exingptr, PTRAJ const& ptraj) : exingptr_(exingptr) {

--- a/Fit/Measurement.hh
+++ b/Fit/Measurement.hh
@@ -32,8 +32,13 @@ namespace KinKal {
       // local functions
       // construct from a hit and reference trajectory
       Measurement(HITPTR const& hit,PTRAJ const& ptraj);
+      // clone op for reinstantiation
+      Measurement(Measurement const&);
+      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const;
       // access the underlying hit
       HITPTR const& hit() const { return hit_; }
+      // other accessors
+      void setHitPtr(HITPTR const& ptr){ hit_ = ptr; }
     private:
       HITPTR hit_ ; // hit used for this measurement
   };
@@ -79,5 +84,20 @@ namespace KinKal {
     return ost;
   }
 
+  // clone op for reinstantiation
+  template <class KTRAJ>
+  Measurement<KTRAJ>::Measurement(Measurement const& rhs){
+    /**/
+  }
+
+  template <class KTRAJ>
+  std::unique_ptr< Effect<KTRAJ> > Measurement<KTRAJ>::clone(CloneContext& context) const{
+    auto casted = std::make_unique< Measurement<KTRAJ> >(*this);
+    HITPTR ptr = context.get(hit_);
+    casted->setHitPtr(ptr);
+    //auto rv = std::make_unique< Effect<KTRAJ> >(casted);
+    auto rv = std::move(casted);
+    return rv;
+  }
 }
 #endif

--- a/Fit/Measurement.hh
+++ b/Fit/Measurement.hh
@@ -37,10 +37,11 @@ namespace KinKal {
       std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const override;
       // access the underlying hit
       HITPTR const& hit() const { return hit_; }
-      // other accessors
-      void setHitPtr(HITPTR const& ptr){ hit_ = ptr; }
     private:
       HITPTR hit_ ; // hit used for this measurement
+
+      // modifiers to support cloning
+      void setHitPtr(HITPTR const& ptr){ hit_ = ptr; }
   };
 
   template<class KTRAJ> Measurement<KTRAJ>::Measurement(HITPTR const& hit,PTRAJ const& ptraj) : hit_(hit) {

--- a/Fit/Measurement.hh
+++ b/Fit/Measurement.hh
@@ -34,7 +34,7 @@ namespace KinKal {
       Measurement(HITPTR const& hit,PTRAJ const& ptraj);
       // clone op for reinstantiation
       Measurement(Measurement const&);
-      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const;
+      std::unique_ptr< Effect<KTRAJ> > clone(CloneContext&) const override;
       // access the underlying hit
       HITPTR const& hit() const { return hit_; }
       // other accessors

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -126,7 +126,7 @@ namespace KinKal {
       TimeRange activeRange() const; // time range of active hits
       void extendTraj(TimeRange const& newrange);
     protected:
-      CloneContext context_;
+      std::unique_ptr<CloneContext> context_;
       Track(Config const& cfg, BFieldMap const& bfield, PTRAJ const& seedtraj );
       void fit(HITCOL& hits, EXINGCOL& exings );
     private:
@@ -207,8 +207,9 @@ namespace KinKal {
       history_(rhs.history()),
       seedtraj_(rhs.seedTraj())
   {
-    context_.clear();
-    CloneContext& context = context_;
+    context_ = std::make_unique<CloneContext>();
+    context_->clear();
+    CloneContext& context = *context_;
     fittraj_ = std::make_unique<PTRAJ>(rhs.fitTraj());
     hits_.reserve(rhs.hits().size());
     for (const auto& ptr: rhs.hits()){

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -45,6 +45,7 @@
 #include "KinKal/Fit/Status.hh"
 #include "KinKal/Fit/Domain.hh"
 #include "KinKal/General/BFieldMap.hh"
+#include "KinKal/General/CloneContext.hh"
 #include "KinKal/General/TimeRange.hh"
 #include "KinKal/General/TimeDir.hh"
 #include "TMath.h"
@@ -99,6 +100,8 @@ namespace KinKal {
       using FitStateArray = std::array<FitState,2>;
       // construct from a set of hits and passive material crossings
       Track(Config const& config, BFieldMap const& bfield, PTRAJ const& seedtraj, HITCOL& hits, EXINGCOL& exings );
+      // copy constructor --- woe to you, weary traveler, who need it
+      Track(const Track& rhs);
       // extend an existing track with either new configuration, new hits, and/or new material xings
       void extend(Config const& config, HITCOL& hits, EXINGCOL& exings );
       // extrapolate the fit through the magnetic field with the given config until the given predicate is satisfied. This function requires
@@ -123,6 +126,7 @@ namespace KinKal {
       TimeRange activeRange() const; // time range of active hits
       void extendTraj(TimeRange const& newrange);
     protected:
+      CloneContext context_;
       Track(Config const& cfg, BFieldMap const& bfield, PTRAJ const& seedtraj );
       void fit(HITCOL& hits, EXINGCOL& exings );
     private:
@@ -195,6 +199,36 @@ namespace KinKal {
     // now fit the track
     fit();
   }
+
+  // copy constructor
+  template<class KTRAJ> Track<KTRAJ>::Track(const Track& rhs) :
+      config_(rhs.configs()),
+      bfield_(rhs.bfield()),
+      history_(rhs.history()),
+      seedtraj_(rhs.seedTraj())
+  {
+    context_.clear();
+    CloneContext& context = context_;
+    fittraj_ = std::make_unique<PTRAJ>(rhs.fitTraj());
+    hits_.reserve(rhs.hits().size());
+    for (const auto& ptr: rhs.hits()){
+      auto hit = ptr->clone(context);
+      hits_.push_back(hit);
+    }
+    exings_.reserve(rhs.exings().size());
+    for (const auto& ptr: rhs.exings()){
+      auto xng = ptr->clone(context);
+      exings_.push_back(xng);
+    }
+    for (const auto& ptr: rhs.domains()){
+        auto dmn = context.get(ptr);
+        domains_.insert(dmn);
+    }
+    for (const auto& ptr: rhs.effects()){
+        auto eff = ptr->clone(context);
+        effects_.push_back(std::move(eff));
+    }
+  };
 
   // extend an existing track
   template <class KTRAJ> void Track<KTRAJ>::extend(Config const& cfg, HITCOL& hits, EXINGCOL& exings) {

--- a/Fit/Track.hh
+++ b/Fit/Track.hh
@@ -100,8 +100,8 @@ namespace KinKal {
       using FitStateArray = std::array<FitState,2>;
       // construct from a set of hits and passive material crossings
       Track(Config const& config, BFieldMap const& bfield, PTRAJ const& seedtraj, HITCOL& hits, EXINGCOL& exings );
-      // copy constructor --- woe to you, weary traveler, who need it
-      Track(const Track& rhs);
+      // copy constructor
+      Track(const Track& rhs, CloneContext& context);
       // extend an existing track with either new configuration, new hits, and/or new material xings
       void extend(Config const& config, HITCOL& hits, EXINGCOL& exings );
       // extrapolate the fit through the magnetic field with the given config until the given predicate is satisfied. This function requires
@@ -126,7 +126,6 @@ namespace KinKal {
       TimeRange activeRange() const; // time range of active hits
       void extendTraj(TimeRange const& newrange);
     protected:
-      std::unique_ptr<CloneContext> context_;
       Track(Config const& cfg, BFieldMap const& bfield, PTRAJ const& seedtraj );
       void fit(HITCOL& hits, EXINGCOL& exings );
     private:
@@ -201,15 +200,12 @@ namespace KinKal {
   }
 
   // copy constructor
-  template<class KTRAJ> Track<KTRAJ>::Track(const Track& rhs) :
+  template<class KTRAJ> Track<KTRAJ>::Track(const Track& rhs, CloneContext& context) :
       config_(rhs.configs()),
       bfield_(rhs.bfield()),
       history_(rhs.history()),
       seedtraj_(rhs.seedTraj())
   {
-    context_ = std::make_unique<CloneContext>();
-    context_->clear();
-    CloneContext& context = *context_;
     fittraj_ = std::make_unique<PTRAJ>(rhs.fitTraj());
     hits_.reserve(rhs.hits().size());
     for (const auto& ptr: rhs.hits()){

--- a/General/CMakeLists.txt
+++ b/General/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(General SHARED
     CylBMap.cc
     CylBFieldMap.cc
     MomBasis.cc
+    CloneContext.cc
 )
 
 # create shared library with ROOT dict

--- a/General/CloneContext.cc
+++ b/General/CloneContext.cc
@@ -1,0 +1,10 @@
+// Ed Callaghan
+// Memoization context for reinstantiating objects with graph relations
+// August 2025
+
+#include "KinKal/General/CloneContext.hh"
+
+void CloneContext::clear(){
+    this->map_.clear();
+}
+

--- a/General/CloneContext.hh
+++ b/General/CloneContext.hh
@@ -1,0 +1,48 @@
+// Ed Callaghan
+// Memoization context for reinstantiating objects with graph relations
+// August 2025
+
+#ifndef KinKal_CloneContext_hh
+#define KinKal_CloneContext_hh
+
+#include <unordered_map>
+#include <memory>
+
+class CloneContext{
+  public:
+    // compiler defaults propagate to underlying stl-map
+    CloneContext() = default;
+   ~CloneContext() = default;
+    // disallow copy-constructor so as to prevent bugs stemming from
+    // failure to propagate instantiations across references to context
+    CloneContext(CloneContext const&) = delete;
+
+    // standard interface:
+    // - if first call for domain ptr, instantiate a clone
+    // - return ptr to clone
+    template<typename T>
+    std::shared_ptr<T> get(const std::shared_ptr<T>&);
+
+    void clear();
+
+  protected:
+    // map of raw address to stl-pointers
+    std::unordered_map <void*, std::shared_ptr<void> > map_;
+
+  private:
+    /**/
+};
+
+template<typename T>
+std::shared_ptr<T> CloneContext::get(const std::shared_ptr<T>& ptr){
+  void* address = static_cast<void*>(ptr.get());
+  if (this->map_.count(address) < 1){
+    auto cloned = ptr->clone(*this);
+    this->map_[address] = static_pointer_cast<void>(cloned);
+  }
+  auto mapped = this->map_[address];
+  auto rv = static_pointer_cast<T>(mapped);
+  return rv;
+}
+
+#endif

--- a/Trajectory/ClosestApproach.hh
+++ b/Trajectory/ClosestApproach.hh
@@ -36,6 +36,8 @@ namespace KinKal {
       // explicitly construct from all content (no calculation)
       ClosestApproach(KTRAJPTR const& ktrajptr, STRAJ const& straj, double precision,
           ClosestApproachData const& tpdata, DVEC const& dDdP, DVEC const& dTdP);
+      // copy constructor
+      ClosestApproach(ClosestApproach<KTRAJ,STRAJ> const&) = default;
       // accessors
       ClosestApproachData const& tpData() const { return tpdata_; }
       KTRAJ const& particleTraj() const { return *ktrajptr_; }

--- a/Trajectory/ClosestApproach.hh
+++ b/Trajectory/ClosestApproach.hh
@@ -68,6 +68,8 @@ namespace KinKal {
       CAHint hint() const { return CAHint(particleToca(),sensorToca()); }
       // equivalence
       ClosestApproach& operator = (ClosestApproach const& other);
+      // other accessors
+      void setTrajectory(KTRAJPTR ktrajptr){ ktrajptr_ = ktrajptr; }
     private:
       double precision_; // precision used to define convergence
       KTRAJPTR ktrajptr_; // kinematic particle trajectory

--- a/Trajectory/PiecewiseTrajectory.hh
+++ b/Trajectory/PiecewiseTrajectory.hh
@@ -4,6 +4,7 @@
 //  class describing a piecewise trajectory.  Templated on a simple time-based trajectory
 //  used as part of the kinematic kalman fit
 //
+#include "KinKal/General/CloneContext.hh"
 #include "KinKal/General/TimeDir.hh"
 #include "KinKal/General/Vectors.hh"
 #include "KinKal/General/MomBasis.hh"
@@ -32,6 +33,9 @@ namespace KinKal {
       PiecewiseTrajectory() {}
       // construct from an initial piece
       PiecewiseTrajectory(KTRAJ const& piece);
+      // clone op for reinstantiation
+      PiecewiseTrajectory(PiecewiseTrajectory<KTRAJ> const&rhs);
+      std::shared_ptr< PiecewiseTrajectory<KTRAJ> > clone(CloneContext&) const;
       // append or prepend a piece, at the time of the corresponding end of the new trajectory.  The last
       // piece will be shortened or extended as necessary to keep time contiguous.
       // Optionally allow truncate existing pieces to accomodate this piece.
@@ -248,6 +252,24 @@ namespace KinKal {
     return ost;
   }
 
+  // clone op for reinstantiation
+  template<class KTRAJ>
+  PiecewiseTrajectory<KTRAJ>::PiecewiseTrajectory(PiecewiseTrajectory<KTRAJ> const& rhs){
+    for (const auto& ptr: rhs.pieces()){
+      auto piece = std::make_shared<KTRAJ>(*ptr);
+      pieces_.push_back(piece);
+    }
+  }
+
+  template<class KTRAJ>
+  std::shared_ptr< PiecewiseTrajectory<KTRAJ> > PiecewiseTrajectory<KTRAJ>::clone(CloneContext& context) const {
+    auto rv = std::make_shared< PiecewiseTrajectory<KTRAJ> >();
+    for (auto const& ptr : pieces_){
+      auto piece = context.get(ptr);
+      rv->append(*piece);
+    }
+    return rv;
+  }
 }
 
 #endif

--- a/Trajectory/PiecewiseTrajectory.hh
+++ b/Trajectory/PiecewiseTrajectory.hh
@@ -34,8 +34,9 @@ namespace KinKal {
       // construct from an initial piece
       PiecewiseTrajectory(KTRAJ const& piece);
       // clone op for reinstantiation
-      PiecewiseTrajectory(PiecewiseTrajectory<KTRAJ> const&rhs);
+      PiecewiseTrajectory(PiecewiseTrajectory<KTRAJ> const&);
       std::shared_ptr< PiecewiseTrajectory<KTRAJ> > clone(CloneContext&) const;
+      PiecewiseTrajectory<KTRAJ>& operator=(PiecewiseTrajectory<KTRAJ> const&) = default;
       // append or prepend a piece, at the time of the corresponding end of the new trajectory.  The last
       // piece will be shortened or extended as necessary to keep time contiguous.
       // Optionally allow truncate existing pieces to accomodate this piece.

--- a/Trajectory/PiecewiseTrajectory.hh
+++ b/Trajectory/PiecewiseTrajectory.hh
@@ -267,7 +267,7 @@ namespace KinKal {
     auto rv = std::make_shared< PiecewiseTrajectory<KTRAJ> >();
     for (auto const& ptr : pieces_){
       auto piece = context.get(ptr);
-      rv->append(*piece);
+      rv.pieces_.push_back(*piece);
     }
     return rv;
   }


### PR DESCRIPTION
This PR implements a copy-constructor for the `Track<>` class template. Track objects contain references to stateful members in the form of "hits," "element crossings," and "effects," the types of which subclass `KinKal`-defined bases, and which may contain references to each other. The construction of an equivalent, but independent and consistent `Track<>` thus requires reinstantiation of the full relationship graph among its members, the struture of which is defined by the subclass implementations. This is achieved via a recursive, memoized cloning scheme, which requires all track members to provide a reinstantiation (`clone()`) method, which should make use of a common reallocation record (`CloneContext`) to ensure that each graph node is only reallocated once; but this simple implementation does not accommodate reference cycles or e.g. explicit self-references.

New classes:
- `CloneContext`: Contains a hash table used to map addresses of to-be-copied `Track<>`-members to the addresses of their newly-allocated clones. Reallocation is done lazily, so that an attempt to lookup the address of an unreallocated object triggers its reallocation via its `clone()` implementation, which may itself involve address lookups and `clone()` calls as necessary.

New functionality:
- `Track<>` class template now contains a `CloneContext` member, which is used in an explicit copy-constructor to coordinate cloning of member objects. This context is `protected` so as to be available to subclasses of `Track<>`, which may need access to the reallocation-map to consistently clone members strictly of the subclass.
- `Hit<>`, `ElementXing<>`, and `Effect<>` class templates now each have default `clone()` methods which throw an exception indicating that explicit cloning must be implemented. No correct default implementation can be provided because arbitrary references in subclasses allow for arbitrary graph structures, for which no infrastructure exists to track. A default exception is preferable to, e.g., a pure-virtual method in that it allows users implementing subclasses to avoid `clone()` implementations unless they actually need to use them, which provides a lower barrier for adoption and prevents e.g. providing (incorrect) empty implementations just to satisfy the interface requirement, which would then later cause problems if a copy is eventually attempted.
- `clone()` methods are provided for `KinKal`-level objects, e.g. `Domain`, `DomainWall`, and `ParameterHit`.
- `clone()` methods are provided for the example `ScintHit`, `SimpleWireHit`, and `StrawXing` class templates.
- Explicit copy-constructors are provided for "flat" objects which do not contain references, e.g. `PiecewiseTrajectory<>` and `ResidualHit<>`.
- Various setters/getters added to support classes as necessary.